### PR TITLE
Add validation dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.venv
+.env

--- a/test/papers_large.json
+++ b/test/papers_large.json
@@ -1,0 +1,6778 @@
+{
+  "machine learning": [
+    {
+      "paperId": "0090023afc66cd2741568599057f4e82b566137c",
+      "title": "A Survey on Bias and Fairness in Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "8f8478d74c312f8ac6b8d4fb9fc50e3e6ec2d549",
+          "title": "BIAS IN ARTIFICIAL INTELLIGENCE: AN ANALYSIS WITH SPECIAL FOCUS ON AUTOMATED CONTENT MODERATION"
+        },
+        {
+          "paperId": "91ce4e6ad8eb5227744df0f6c8e2bf4fd8d1d883",
+          "title": "Explaining Fairness Violations using Machine Unlearning"
+        },
+        {
+          "paperId": "c1dc05b322ff5f7bd784d056920772de9ed55b7d",
+          "title": "Exploration of Potential New Benchmark for Fairness Evaluation in Europe"
+        },
+        {
+          "paperId": "53a0bac11eee69dd2f95f683fb7851117c4f99d0",
+          "title": "From Laws to Algorithms: Detecting Unfairness in Machine Learning Models"
+        },
+        {
+          "paperId": "de89f6d78e6ca015cd44077f0072860f784b14a9",
+          "title": "Addressing Bias in Natural Language Processing (NLP) Models: Techniques and Implications"
+        },
+        {
+          "paperId": "0c7ee00dd7431fd3179b8fda65297b464900af06",
+          "title": "Analyzing Fairness of Computer Vision and Natural Language Processing Models"
+        },
+        {
+          "paperId": "2f4eb282689f3bd17a569e3c7b970e788cf7ac63",
+          "title": "Ethical AI: Navigating the Challenges of Bias, Fairness, and Transparency in Machine Learning"
+        },
+        {
+          "paperId": "e2bcb5181f7affc6f2e56a3f713d8d9f754f4edd",
+          "title": "Deep Learning Approach for Evaluating Fairness in LLMs"
+        },
+        {
+          "paperId": "a0fd5ca02894cb51add87f2f23c4c6e794337f2b",
+          "title": "EquiPy: Sequential Fairness using Optimal Transport in Python"
+        },
+        {
+          "paperId": "db9d467f153856450c02f8c5b8cc07241aad596b",
+          "title": "Active Data Sampling and Generation for Bias Remediation"
+        },
+        {
+          "paperId": "f88236c6fe4b504cef364222cd88de3da84db8fb",
+          "title": "Fair Sufficient Representation Learning"
+        },
+        {
+          "paperId": "791c406b4155b8dc050ecc3af920fd0dae2535f6",
+          "title": "On the Origins of Sampling Bias: Implications on Fairness Measurement and Mitigation"
+        },
+        {
+          "paperId": "22e00044976f3ae97afef9be06e411f29ca5d527",
+          "title": "Machine Learning Should Maximize Welfare, Not (Only) Accuracy"
+        },
+        {
+          "paperId": "9e90796e971a31f10be4a23ddff894f4fef8243b",
+          "title": "Towards Large Language Models that Benefit for All: Benchmarking Group Fairness in Reward Models"
+        },
+        {
+          "paperId": "2d4d2d3eb9adfcb311c49ee62f07f2d4e87e984e",
+          "title": "The Impact of Bias in Machine Learning Models"
+        },
+        {
+          "paperId": "c81bed444d8ac7ed0ab8191da856f9bdc0936c67",
+          "title": "FairnessEval: a Framework for Evaluating Fairness of Machine Learning Models"
+        },
+        {
+          "paperId": "a378d4b8b6e7916b2f7e8df30d414fbfaedccd07",
+          "title": "Beyond Accuracy: What Matters in Designing Well-Behaved Models?"
+        },
+        {
+          "paperId": "5b3931747b2113d51ffc2cdbfcfd61f4fcd595fd",
+          "title": "Fair Learning by Model Averaging (Revised Version)"
+        },
+        {
+          "paperId": "11a1352e86173f40f8d0d8e922d9b283ad9a0e49",
+          "title": "Guidelines for designing visualization tools for group fairness analysis in binary classification"
+        },
+        {
+          "paperId": "0b3890065b98d5890a111504b584e90c9f3c3b35",
+          "title": "Auditing large language models for race & gender disparities: Implications for artificial intelligence-based hiring"
+        }
+      ]
+    },
+    {
+      "paperId": "597bd2e45427563cdf025e53a3239006aa364cfc",
+      "title": "Open Graph Benchmark: Datasets for Machine Learning on Graphs",
+      "recommendations": [
+        {
+          "paperId": "33f9f146f4258a13889f75760502b230d472b039",
+          "title": "G-OSR: A Comprehensive Benchmark for Graph Open-Set Recognition"
+        },
+        {
+          "paperId": "a9c2f56ef61ec5ca6d8b47179aeec6999844e75d",
+          "title": "Exploring Graph Tasks with Pure LLMs: A Comprehensive Benchmark and Investigation"
+        },
+        {
+          "paperId": "f07646796bb0869712b185177e71d32d17b5e377",
+          "title": "GiGL: Large-Scale Graph Neural Networks at Snapchat"
+        },
+        {
+          "paperId": "9da5571ca6b8657af23bcb51fdf2ecc5a01ebf65",
+          "title": "Graph Neural Networks for Databases: A Survey"
+        },
+        {
+          "paperId": "ee0a9ccaa6ff27bb71bf3b867b2a4429ac48f6d6",
+          "title": "Towards Quantifying Long-Range Interactions in Graph Machine Learning: a Large Graph Dataset and a Measurement"
+        },
+        {
+          "paperId": "a95b3f99b44949eda8b99ba9b177650b3cc39241",
+          "title": "UGC: Universal Graph Coarsening"
+        },
+        {
+          "paperId": "dc67390a0aff9c719a780e6510dca98a265b3b0c",
+          "title": "GraphGen+: Advancing Distributed Subgraph Generation and Graph Learning On Industrial Graphs"
+        },
+        {
+          "paperId": "1a454582d3b3aaa6c6cd5b2be075958d13423f78",
+          "title": "RAG vs. GraphRAG: A Systematic Evaluation and Key Insights"
+        },
+        {
+          "paperId": "2db5a52f4858d8bd8f79824fe6d186fe3a361334",
+          "title": "Scale-Free Graph-Language Models"
+        },
+        {
+          "paperId": "7d23c33953f71102509170b8f8585cf388e79c83",
+          "title": "A Comparative Study of GNNs and Rule-Based Methods for Synthetic Social Network Generation"
+        },
+        {
+          "paperId": "ea0ba110d34bfa1bed1b1919a3bb367f84bdfa38",
+          "title": "RTD-Lite: Scalable Topological Analysis for Comparing Weighted Graphs in Learning Tasks"
+        },
+        {
+          "paperId": "586e51d87c24d9a3f2346f7d510d8488e3d60f3a",
+          "title": "Graph Prompt Clustering."
+        },
+        {
+          "paperId": "5c18f91dfa622c3c6ba455de9df5535a48bff463",
+          "title": "Out-of-Distribution Detection on Graphs: A Survey"
+        },
+        {
+          "paperId": "ef561670ac85e51e8ae39f0a5485f4c2afd8b75b",
+          "title": "A Survey of Cross-domain Graph Learning: Progress and Future Directions"
+        },
+        {
+          "paperId": "ec0a420a5b9ed949dd7934e9f5b5f89a04a2840e",
+          "title": "Position: Graph Learning Will Lose Relevance Due To Poor Benchmarks"
+        },
+        {
+          "paperId": "9cce0fbd282eef1a9e26f5bb6a04ffb9cb89f622",
+          "title": "GKG-LLM: A Unified Framework for Generalized Knowledge Graph Construction"
+        },
+        {
+          "paperId": "b5959dfcc875a92f360ba305b58aa0d6cc8f9940",
+          "title": "Network Embedding Exploration Tool (NEExT)"
+        },
+        {
+          "paperId": "f0856f52a654c4e5c0d8ff37ced725af624d5d23",
+          "title": "Unsupervised Inductive Node Representation Learning for Dynamic Graphs"
+        },
+        {
+          "paperId": "d1d2d06de1a57a7aa32cf6a5d71ac07eb23d0012",
+          "title": "Data-centric Federated Graph Learning with Large Language Models"
+        },
+        {
+          "paperId": "05c86e2ecdd3e2b3945a41305ec683a1babc2af0",
+          "title": "Graph neural networks extrapolate out-of-distribution for shortest paths"
+        }
+      ]
+    },
+    {
+      "paperId": "360ca02e6f5a5e1af3dce4866a257aafc2d6d6f5",
+      "title": "Machine learning - a probabilistic perspective",
+      "recommendations": [
+        {
+          "paperId": "92e77426658ee7505b18113b3c4c3c75923d8e8e",
+          "title": "A Review on Various Machine Learning Algorithms"
+        },
+        {
+          "paperId": "a45c73fb27aab33cc4f21c17b894c39eb25a0cd7",
+          "title": "Statistical Query Hardness of Multiclass Linear Classification with Random Classification Noise"
+        },
+        {
+          "paperId": "c3792ddac7ac736f13da71f8d6dd58e47edc2b8d",
+          "title": "Robust Learning of Multi-index Models via Iterative Subspace Approximation"
+        },
+        {
+          "paperId": "ce56e39852906b82326dae0173c0a5ab5c468821",
+          "title": "Algebraic Machine Learning: Learning as computing an algebraic decomposition of a task"
+        },
+        {
+          "paperId": "18b9e815547c3370e42a960f0a21c8d2eeb31f1a",
+          "title": "Batch List-Decodable Linear Regression via Higher Moments"
+        },
+        {
+          "paperId": "00fc5ebddca6980a8ff8fbce9cedb98595187bb3",
+          "title": "A Rank-One-Update Method for the Training of Support Vector Machines"
+        },
+        {
+          "paperId": "dddc76f405b03d6233814347afd9d1da562e3050",
+          "title": "A Convex formulation for linear discriminant analysis"
+        },
+        {
+          "paperId": "1159249648128ed8bf20f9b5ef93174702b2e27d",
+          "title": "Learning-Augmented Frequent Directions"
+        },
+        {
+          "paperId": "869609edb3c1f99e54870a5c0bb51c1cc6420087",
+          "title": "Logic Replicant: a New Machine Learning Algorithm for Multiclass Classification in Small Datasets"
+        },
+        {
+          "paperId": "62abfdf89c22b12b45a5180f4e9b91a130d16d9c",
+          "title": "A statistical theory of overfitting for imbalanced classification"
+        },
+        {
+          "paperId": "4fd964ece5b0d0a55f125cebf0ff1ac727a3c3c6",
+          "title": "Machine Learning Report"
+        },
+        {
+          "paperId": "b047a6c9bda295f9258ca85f988908ae75c939e6",
+          "title": "Signature methods in machine learning"
+        },
+        {
+          "paperId": "f08e6c60dd0a3e65e114f26dcfd4eb3e2c25ccb0",
+          "title": "High-dimensional ridge regression with random features for non-identically distributed data with a variance profile"
+        },
+        {
+          "paperId": "e49197fbcb7fd939a9e0226c468d8602d002de3d",
+          "title": "OMAL: A Multi-Label Active Learning Approach from Data Streams"
+        },
+        {
+          "paperId": "61c0cdb5c03ff08ee7e48aa375bb7714d14aaa65",
+          "title": "Monotone Oblique Decision Trees"
+        },
+        {
+          "paperId": "6fdded27361a81dfe2a0072526e194aead29513b",
+          "title": "Machine Learning with Python"
+        },
+        {
+          "paperId": "74debbcb41d24fbbaac1cce68d6a6e44d72906cc",
+          "title": "A Survey of Text Classification Under Class Distribution Shift"
+        },
+        {
+          "paperId": "6ce4c59948d4ffcfd0773f2ab7742959f892ded0",
+          "title": "Evaluating the Trade-offs Between Machine Learning and Deep Learning: A Multi-Dimensional Analysis"
+        },
+        {
+          "paperId": "4e9e14db1e0acc3edb11cb9af895b7303c8f56bd",
+          "title": "An Efficient Plugin Method for Metric Optimization of Black-Box Models"
+        },
+        {
+          "paperId": "cd195391f768fae9b4285fefdaa53632b07baa7e",
+          "title": "Tradeoffs in Processing Queries and Supporting Updates over an ML-Enhanced R-tree"
+        }
+      ]
+    },
+    {
+      "paperId": "668b1277fbece28c4841eeab1c97e4ebd0079700",
+      "title": "Pattern Recognition and Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "5cf0257c3d0b9580bc3a287359328588c8f45647",
+          "title": "Machine learning and high dimensional vector search"
+        },
+        {
+          "paperId": "47e19ceb129f89f83cd526dbd062e3b894fd73f7",
+          "title": "Comparisons of Supervised Artiﬁcial Neural Networks With Population-Based Statistical Probability Models in Moderate Sized Samples"
+        },
+        {
+          "paperId": "3da98cf3773fca4eb5b7a35cd50b16ce7d737d8d",
+          "title": "A Review on K nearest Neighbour Classification Technique in Machine Learning"
+        },
+        {
+          "paperId": "cf0391b858eda123c09d103cf4bcbcfdc09f606a",
+          "title": "AIのハルシネーションをどう抑えるか"
+        },
+        {
+          "paperId": "b621352ddb9a61ea90df9cb11423b8dd63eee4ab",
+          "title": "Axes that matter: PCA with a difference"
+        },
+        {
+          "paperId": "76189670baa3190295d1b520ddfaef40a9451f27",
+          "title": "Analyzing the Performance of SVM and KNN in Supervised Learning for Classification"
+        },
+        {
+          "paperId": "fa89e5e84aa120a3ea1e7ad9f972a64fd8707cf7",
+          "title": "Comparisons of Supervised Artificial Neural Networks With Population-Based Statistical Probability Models in Moderate Sized Samples"
+        },
+        {
+          "paperId": "b2e0770d063487ddd280d7ab64fe7fc5c607c88d",
+          "title": "Survey on Algorithms for multi-index models"
+        },
+        {
+          "paperId": "c7cd58340f575a1e4abb51778a5e56cac2bb4232",
+          "title": "Industrial and Systems Engineering Courses (ISE)"
+        },
+        {
+          "paperId": "cd7d411bf6860fa1f782b7c0c41123cc58caa13f",
+          "title": "A Note on the Asymptotic Properties of the GLS Estimator in Multivariate Regression with Heteroskedastic and Autocorrelated Errors"
+        },
+        {
+          "paperId": "87dd3b288989db9ffd86eab312045edd4408d276",
+          "title": "Mean estimation in high dimension"
+        }
+      ]
+    },
+    {
+      "paperId": "4a2b5058000d567036fc9aaad75bbf71cce53002",
+      "title": "Evaluation metrics and statistical tests for machine learning",
+      "recommendations": [
+        {
+          "paperId": "4590abe5c73c4df113825120dc917647d171c5ea",
+          "title": "Comparative Analysis of Traditional Machine Learning and Deep Learning Methods: Performance on Datasets of Varying Complexity"
+        },
+        {
+          "paperId": "4e89b3b8d4fb0095c6e0f5926c9fe6bd828f4e5d",
+          "title": "Optimizing Multiclass Classification Using Convolutional Neural Networks with Class Weights and Early Stopping for Imbalanced Datasets"
+        },
+        {
+          "paperId": "6cb2a925a6d7c3c99bb8ae6f1f171eff3fe2ba25",
+          "title": "EnsembleDRM Model for Multiclass Image Classification in Deep Learning"
+        },
+        {
+          "paperId": "aa58d096793f7cb532bb7859009c0dfb34176fbc",
+          "title": "Application of Deep Learning and Transfer Learning Techniques for Medical Image Classification"
+        },
+        {
+          "paperId": "73d8b5102871526a3c2adc5065c2b4172ed60a01",
+          "title": "Multi-label out-of-distribution detection via evidential learning"
+        },
+        {
+          "paperId": "45d78f765ecbd419cefc66c344df641e8402d304",
+          "title": "A Review on the Applications of Machine Learning and Deep Learning Algorithms for Image Recognition"
+        },
+        {
+          "paperId": "6ce4c59948d4ffcfd0773f2ab7742959f892ded0",
+          "title": "Evaluating the Trade-offs Between Machine Learning and Deep Learning: A Multi-Dimensional Analysis"
+        },
+        {
+          "paperId": "649e1a1c04512fe9c6abb0e644bc77563ca7886a",
+          "title": "Advantages of Machine Learning in Image Recognition and Detection"
+        },
+        {
+          "paperId": "285a9ed0bc328c8c905cf7db2159b4934272bbb8",
+          "title": "A REVIEW ON HYBRID AI TECHNIQUES FOR CANCER DETECTION"
+        },
+        {
+          "paperId": "4cff08451a47f5dfd536788b162d35f14eccb82f",
+          "title": "Predictive Capability of a Condensed CNN Model in Discovering Patterns of Coronary Heart Disease"
+        },
+        {
+          "paperId": "2b26b734818c58071cfb54578abf72b0f7383f74",
+          "title": "Anomaly Detection Using Computer Vision: A Comparative Analysis of Class Distinction and Performance Metrics"
+        },
+        {
+          "paperId": "fe1048102f850d982ef45638748ce1482468d3f9",
+          "title": "Employee Retention Analysis: Insights and Predictive Modeling With Machine Learning Techniques"
+        },
+        {
+          "paperId": "d4004fb4d4544a3b0e9a808bf2a17c9dfaf155f9",
+          "title": "A Review on the Applications of Machine Learning and Deep Learning Techniques for Skin Cancer Detection"
+        },
+        {
+          "paperId": "2ea7c23c0ab790029053f2a63420575dfe7a751d",
+          "title": "A Computational Framework For Recognition Of Mice Cancer Based On Vits Method"
+        },
+        {
+          "paperId": "4c3e3d9d6495e17b5003cf93ef13649b18c70fb0",
+          "title": "Investigations on Convolutional Neural Network Based on Image Recognition"
+        },
+        {
+          "paperId": "715b5a761ed0e84000954a928519935ec35fb071",
+          "title": "A Tale of Two Classes: Adapting Supervised Contrastive Learning to Binary Imbalanced Datasets"
+        },
+        {
+          "paperId": "85b6d45d09eb59e68d04a553729f9b7b0d73e3d2",
+          "title": "ON INFORMATICS"
+        },
+        {
+          "paperId": "b92b2b0e937c3754c986542a2517143ebbf0b435",
+          "title": "A Comparative Study of Ensemble Learning and Neural Networks for the Heart Disease Prediction"
+        },
+        {
+          "paperId": "5cf6f0a6ff472b5e5ff263507c121c1b1a0a6b57",
+          "title": "Applications of deep learning in automated ‎image classification: a review"
+        },
+        {
+          "paperId": "0685a57122565fd4155884b1bd19635df1aeb8ba",
+          "title": "Lung Cancer Detection and Classification Using Machine Learning: A Literature Review"
+        }
+      ]
+    },
+    {
+      "paperId": "f75b70c9d7078724b592ec3e21de705e7b6ff73f",
+      "title": "Double/Debiased Machine Learning for Treatment and Structural Parameters",
+      "recommendations": [
+        {
+          "paperId": "e267705d4f2208ce4f372306fe5434690fcc40c7",
+          "title": "Finite sample expansions for semiparametric plug-in estimation and inference for BTL model"
+        },
+        {
+          "paperId": "50600c01041e376dfe5005befc0468c63b879147",
+          "title": "Treatment Effects Inference with High-Dimensional Instruments and Control Variables"
+        },
+        {
+          "paperId": "41c9f3572900e191d9363bd8fd82af1b6db4903e",
+          "title": "Robust group and simultaneous inferences for high-dimensional single index model"
+        },
+        {
+          "paperId": "15b8708a12333f3b022556ed57b55e5a87e3c56e",
+          "title": "Support estimation and sign recovery in high‐dimensional heteroscedastic mean regression"
+        },
+        {
+          "paperId": "3882e5bcc297ab4f4a7c86dcee39ccf625d9a5b1",
+          "title": "Bayesian Shrinkage in High-Dimensional VAR Models: A Comparative Study"
+        },
+        {
+          "paperId": "cc7200117aab07dad4191cdd15169d593ef3999a",
+          "title": "LEAST TRIMMED SQUARES: NUISANCE PARAMETER FREE ASYMPTOTICS"
+        },
+        {
+          "paperId": "bc963756ee29767ec71ea4f5efd99527f6272281",
+          "title": "Universality of High-Dimensional Logistic Regression and a Novel CGMT under Dependence with Applications to Data Augmentation"
+        },
+        {
+          "paperId": "69775abf4f6c0641491be966d97b3a1c81d81372",
+          "title": "Semiparametric Counterfactual Regression"
+        },
+        {
+          "paperId": "153e2fecd0c9da47cc74064003ede9908b137993",
+          "title": "A ﬂexible framework for hypothesis testing in high dimensions"
+        },
+        {
+          "paperId": "1c83139aa713be1e42c581616d5d0e7895ad8a96",
+          "title": "Generalized C ( 𝜶 ) tests with nonstandard convergence rates"
+        },
+        {
+          "paperId": "8fa09ef1a4050eb52e03d63f3d1aab4dae9f45ee",
+          "title": "Regularized zero-inflated Bernoulli regression model"
+        },
+        {
+          "paperId": "fae6cb46240a790492ec8c01cada0c782bdefb3a",
+          "title": "Optimal Algorithms in Linear Regression under Covariate Shift: On the Importance of Precondition"
+        },
+        {
+          "paperId": "3f86e56f8e94ddb341350424799c75a2374a8d22",
+          "title": "Empirical likelihood approach for high-dimensional moment restrictions with dependent data"
+        },
+        {
+          "paperId": "ec550efd256660affe8f8e8a3ccc8a7b36ae9469",
+          "title": "Semiparametric Triple Difference Estimators"
+        },
+        {
+          "paperId": "6ebb6c1715e9424077ecb217ff23c91356ec5e04",
+          "title": "gintreg: Generalized interval regression"
+        },
+        {
+          "paperId": "2f1d0e071300ec8092a3d488e37a3fb9508dbe11",
+          "title": "Optimal Data Splitting for Holdout Cross-Validation in Large Covariance Matrix Estimation"
+        },
+        {
+          "paperId": "5e293a0b24167c2274725faef173bb5398ffcd4e",
+          "title": "Nonparametric Estimation of Local Treatment Effects with Continuous Instruments"
+        },
+        {
+          "paperId": "6a00362cef5dadef28da5b3d576fc2dce22838c8",
+          "title": "Functional structural equation models with out-of-sample guarantees"
+        },
+        {
+          "paperId": "23cfe7d1b964e0d94499d20971a8998ddd5b4625",
+          "title": "Improving variable selection properties by leveraging external data"
+        },
+        {
+          "paperId": "5dedbc571eefa8dcc46e90d031fdb71a4a53a265",
+          "title": "Inference for DEA estimators of malmquist productivity indices: an overview, further improvements, and a guide for practitioners"
+        }
+      ]
+    },
+    {
+      "paperId": "36eb6fea39ce06e2807f074fa3d5e79ed0f2bcef",
+      "title": "Probabilistic Graphical Models: Principles and Techniques - Adaptive Computation and Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "3c858168d4fb69d62744516d987c05fd3def5343",
+          "title": "Bayesian Methods in Machine Learning Applications and Challenges"
+        },
+        {
+          "paperId": "eba71aee2eef29c43687dae24f6dbba1397ca0c4",
+          "title": "Bayesian Teaching Enables Probabilistic Reasoning in Large Language Models"
+        },
+        {
+          "paperId": "c8114d43fe130074733f8851daef4ae796e10c66",
+          "title": "On the Functoriality of Belief Propagation Algorithms on finite Partially Ordered Sets"
+        },
+        {
+          "paperId": "a1e1f241b5cf5c2266af5d799d34f92e9071586e",
+          "title": "A Guide to Bayesian Networks Software Packages for Structure and Parameter Learning -- 2025 Edition"
+        },
+        {
+          "paperId": "8a8f11c50558b988a7edccb53df75499c32baa3a",
+          "title": "Gradient-bridged Posterior: Bayesian Inference for Models with Implicit Functions"
+        },
+        {
+          "paperId": "552375feaab401aeba301375bd7de659ac2b4104",
+          "title": "Learning local neighborhoods of non-Gaussian graphical models: A measure transport approach"
+        },
+        {
+          "paperId": "e1cf32ee368d215a5d84a3b3034b60b14917d231",
+          "title": "No-prior Bayesian inference reIMagined: probabilistic approximations of inferential models"
+        },
+        {
+          "paperId": "a602aac80fe6a27aa81382c71f9029c221989185",
+          "title": "Selective Inference in Graphical Models via Maximum Likelihood"
+        },
+        {
+          "paperId": "774a86c5367dd11d2ad571bd4b77b8012f0ba7a3",
+          "title": "Bayesian Tree Models for Survey Sample Data"
+        },
+        {
+          "paperId": "486082eef960af5402482febe13ac6f17f1fd039",
+          "title": "Stochastic Computation for AI: Bayesian Inference, Uncertainty, and Optimization"
+        },
+        {
+          "paperId": "818c0bf0cc6f15a7edc20a11e30a267436a72ddf",
+          "title": "Computational Statistics and Data Analysis"
+        },
+        {
+          "paperId": "1997ca1fd12b3c3f7ab7c99872460569e820199d",
+          "title": "Mixture models for data with unknown distributions"
+        },
+        {
+          "paperId": "1c1ecbba2259867c98f7eafec12ae87ffdd6f39b",
+          "title": "Neural Bayes inference for complex bivariate extremal dependence models"
+        },
+        {
+          "paperId": "c17796e85131d81fe11b54c67e03e6d9fffe81c2",
+          "title": "MIT Open Access Articles A nonparametric belief solution to the Bayes tree"
+        },
+        {
+          "paperId": "28312f9d65747dc091a64562b4303b5eb5b6c431",
+          "title": "Error Bounds Revisited, and How to Use Bayesian Statistics While Remaining a Frequentist"
+        },
+        {
+          "paperId": "522920c22501f62af6aa109553a4576557835162",
+          "title": "RLBayes: a Bayesian Network Structure Learning Algorithm via Reinforcement Learning-Based Search Strategy"
+        },
+        {
+          "paperId": "86a15b43bdf4e24794ab76fc8942a2c523825648",
+          "title": "Bayesian model criticism using uniform parametrization checks"
+        },
+        {
+          "paperId": "f369cecf355cdd8087b998cb6a671db20563bf34",
+          "title": "MIT Open Access Articles A generalized Bayesian approach to model calibration"
+        },
+        {
+          "paperId": "041e36812cafdf1c8d710daf01807683ae04b474",
+          "title": "Bayesian calculus and predictive characterizations of extended feature allocation models"
+        },
+        {
+          "paperId": "92e77426658ee7505b18113b3c4c3c75923d8e8e",
+          "title": "A Review on Various Machine Learning Algorithms"
+        }
+      ]
+    },
+    {
+      "paperId": "0b544dfe355a5070b60986319a3f51fb45d1348e",
+      "title": "Learning Phrase Representations using RNN Encoder–Decoder for Statistical Machine Translation",
+      "recommendations": [
+        {
+          "paperId": "0b907ce4049ba8df81c1ce80fcc78655742dac2f",
+          "title": "MTLM: an Innovative Language Model Training Paradigm for ASR"
+        },
+        {
+          "paperId": "11bb2b2c9b8cfda0c80e0da05223a3701d76a905",
+          "title": "Self-Vocabularizing Training for Neural Machine Translation"
+        },
+        {
+          "paperId": "ac0ef442016704a2d495fccc013873e39da1724d",
+          "title": "Beyond Decoder-only: Large Language Models Can be Good Encoders for Machine Translation"
+        },
+        {
+          "paperId": "0a5bf2500bd6b8799dc4000c00539aec84e1ace2",
+          "title": "UvA-DARE ("
+        },
+        {
+          "paperId": "556bd505f8c77f3374aaba88df5bea1c4cd60ab4",
+          "title": "UvA-DARE ("
+        },
+        {
+          "paperId": "d073267066dea4dea285c4cdba5e55c743260b4d",
+          "title": "UvA-DARE ("
+        },
+        {
+          "paperId": "d9ad557cb4878ae4899b796f22d80da440a6fa96",
+          "title": "UvA-DARE ("
+        },
+        {
+          "paperId": "9d540305ce24a273221afb3ce787ca832d5ee0dc",
+          "title": "UvA-DARE ("
+        },
+        {
+          "paperId": "1e60b081ecef624cb37887c3380e4a2687b6f3fd",
+          "title": "Long Short-Term Memory Used for Enhancing Bilingual Machine Translation Approach"
+        },
+        {
+          "paperId": "aeaa926346440fbef60d11e80b221de2bd11c4f7",
+          "title": "Next Word Prediction for Urdu using Deep Learning Techniques"
+        },
+        {
+          "paperId": "125d08f3eca88f9b7da66f7740fd6af7c12b5e48",
+          "title": "Syntactic Learnability of Echo State Neural Language Models at Scale"
+        },
+        {
+          "paperId": "da5f6553eb85eb9c1e83b0522ab411755aa01ae4",
+          "title": "ABBIE: Attention-Based BI-Encoders for Predicting Where to Split Compound Sanskrit Words"
+        },
+        {
+          "paperId": "874c0082915ac81268b906f8974e25bbecc33364",
+          "title": "Mapping 1,000+ Language Models via the Log-Likelihood Vector"
+        },
+        {
+          "paperId": "3c235eb71627f78d7151e9bef8897cbe4ea3b0bc",
+          "title": "Cognate Production Using Character-Based Neural Machine Translation Without Segmentation"
+        },
+        {
+          "paperId": "cdb2e6bf053e3a3dbe44b7b030a46bfa1ca30c65",
+          "title": "PREDICTIVE TEXT GENERATION WITH LONG SHORT-TERM MEMORY BASED LANGUAGE MODELS"
+        },
+        {
+          "paperId": "4eb9206ac1d4ad8e58c2b470cd44df242c6c9f2e",
+          "title": "Automated Feature Labeling with Token-Space Gradient Descent"
+        },
+        {
+          "paperId": "db67a863bc3edbaf11f23f8ecfa0c3079bba234f",
+          "title": "Building English ASR model with regional language support"
+        },
+        {
+          "paperId": "e25987913b6ccca0b8a8d7c495b388e86f6a7115",
+          "title": "Lost in Space: Optimizing Tokens for Grammar-Constrained Decoding"
+        },
+        {
+          "paperId": "754869aa5927c3c633971da379dd76e74763958e",
+          "title": "Local Normalization Distortion and the Thermodynamic Formalism of Decoding Strategies for Large Language Models"
+        },
+        {
+          "paperId": "fe7045c27437e2df7c0432ff5678c58ba02d2b95",
+          "title": "Concatenated Vector Representation with the Asymmetric GloVe Model"
+        }
+      ]
+    },
+    {
+      "paperId": "b05f97e84e0867b63f6271cf5d42eacaa0d9e68e",
+      "title": "PDEBENCH: An Extensive Benchmark for Scientific Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "34178133280f5196339df1c01d9c08cd71864d42",
+          "title": "DeepSeek vs. ChatGPT: A Comparative Study for Scientific Computing and Scientific Machine Learning Tasks"
+        },
+        {
+          "paperId": "5c5ef1b32e5caf7e80ee811807f64d7fbd044baf",
+          "title": "DeepSeek vs. ChatGPT vs. Claude: A Comparative Study for Scientific Computing and Scientific Machine Learning Tasks"
+        },
+        {
+          "paperId": "e8392ec1af309c49460c3c35bb164e7875660631",
+          "title": "APBench and benchmarking large language model performance in fundamental astrodynamics problems for space engineering"
+        },
+        {
+          "paperId": "acb504e4aa78456ac10fff6c8caf673534fe1239",
+          "title": "To Use or Not to Use a Universal Force Field"
+        },
+        {
+          "paperId": "ffea1f0412dfa8149535dbfc3ca0e94e629afad7",
+          "title": "KernelBench: Can LLMs Write Efficient GPU Kernels?"
+        },
+        {
+          "paperId": "3e889ce4e3c0c7c165d5d80371937d16675d8607",
+          "title": "madupite: A High-Performance Distributed Solver for Large-Scale Markov Decision Processes"
+        },
+        {
+          "paperId": "c6550bbc1929fb27ecc079661eede21c3732a430",
+          "title": "BurTorch: Revisiting Training from First Principles by Coupling Autodiff, Math Optimization, and Systems"
+        },
+        {
+          "paperId": "099bddaf1fc2c2c67000cebd812333abccb76470",
+          "title": "Machine Learned Force Fields: Fundamentals, its reach, and challenges"
+        },
+        {
+          "paperId": "6ce4c59948d4ffcfd0773f2ab7742959f892ded0",
+          "title": "Evaluating the Trade-offs Between Machine Learning and Deep Learning: A Multi-Dimensional Analysis"
+        },
+        {
+          "paperId": "7ecb773db1f7ce8053710986189d4bdfa38a46ad",
+          "title": "Theoretical Physics Benchmark (TPBench) - a Dataset and Study of AI Reasoning Capabilities in Theoretical Physics"
+        },
+        {
+          "paperId": "68da0955d23e1b5e4f23913bdf4d241ed8d0afb5",
+          "title": "Operator Learning: A Statistical Perspective"
+        },
+        {
+          "paperId": "e0a43b162f7619793a49dbe357ede34d31a3f8ee",
+          "title": "Generators for Large-Scale Stochastic Simulation-Optimization Experiments"
+        },
+        {
+          "paperId": "705ab917503e31bc4e71d4ed1754a1d6db165ce2",
+          "title": "Tracking of Online Parameter Fine-tuning in Scientific Workflows"
+        },
+        {
+          "paperId": "f629f105cd08a15ee6020ecec65b9e184327cf14",
+          "title": "Resource-Efficient Machine Learning"
+        },
+        {
+          "paperId": "d2d5f7899414a00fb676a893e79931c9ab63aa1c",
+          "title": "I/O in Machine Learning Applications on HPC Systems: A 360-degree Survey"
+        },
+        {
+          "paperId": "53f7efc5cadfe7d1a9313fd649947fbf8f22c553",
+          "title": "BixBench: a Comprehensive Benchmark for LLM-based Agents in Computational Biology"
+        },
+        {
+          "paperId": "f01400f41bfa3c4e0325b83eb63c3cdd7256b941",
+          "title": "PFD: Automatically Generating Machine Learning Force Fields from Universal Models"
+        },
+        {
+          "paperId": "86aba4ec3eecdb111d24e512fec2485517ff88f2",
+          "title": "Accelerating Transient CFD through Machine Learning-Based Flow Initialization"
+        },
+        {
+          "paperId": "856417d39e57720f70d2f93f1c6eae28fc336ebb",
+          "title": "Effective Field Neural Network"
+        },
+        {
+          "paperId": "65288cf45debd6651034fff4bab24c3b873a5edb",
+          "title": "Stochastic Rounding for LLM Training: Theory and Practice"
+        }
+      ]
+    },
+    {
+      "paperId": "2dec2970a33f421ac02ed0ae6fe27537c9f1ae45",
+      "title": "Applied Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "92e77426658ee7505b18113b3c4c3c75923d8e8e",
+          "title": "A Review on Various Machine Learning Algorithms"
+        },
+        {
+          "paperId": "43f65f283ff0ecfee33d7341260fc3f71ebe8f48",
+          "title": "Study on a Combined Approach of Using Machine Learning and Data Mining Techniques"
+        },
+        {
+          "paperId": "d1857e8610f22db83a16a3c37291ff1fd585d28d",
+          "title": "Performance Prediction of Learning Programming - Machine Learning Approach"
+        },
+        {
+          "paperId": "6fdded27361a81dfe2a0072526e194aead29513b",
+          "title": "Machine Learning with Python"
+        },
+        {
+          "paperId": "fdac022439554211a901800a92eefff0687aaad8",
+          "title": "A Comprehensive Overview of Machine Learning Models: Techniques, Applications, and Future Directions"
+        },
+        {
+          "paperId": "032d6f66527cf2b4300952629bbdeccb1d79e94d",
+          "title": "Supervised Vs. Unsupervised Learning: A Comparative Study in Modern AI System"
+        },
+        {
+          "paperId": "3744cb6a330a2a8dc1b14326d10b525916f29bc0",
+          "title": "Question paper analysis using machine learning"
+        },
+        {
+          "paperId": "4d703a87e7e2df7e2ca53db64ada3c434c2808fe",
+          "title": "A STUDENT PERFORMANCE PREDICTION APPROACH USING MACHINE LEARNING"
+        },
+        {
+          "paperId": "570ab5404126e0e3688d2883588c078b84144882",
+          "title": "LITERATURE REVIEW ON AUTOMATED MACHINE LEARNING (AUTOML)"
+        },
+        {
+          "paperId": "111f4326523234c8f63d451b8852250aab6ab662",
+          "title": "The Practice and Application of Machine Learning in Data Analysis"
+        },
+        {
+          "paperId": "111f4326523234c8f63d451b8852250aab6ab662",
+          "title": "The Practice and Application of Machine Learning in Data Analysis"
+        },
+        {
+          "paperId": "8bf6597b9f9f5aaf7a8cdbd9b15f3c3d5cc6b04e",
+          "title": "Predictive Analytics for Student Online Learning Performance Using Machine Learning and Data Mining Techniques"
+        },
+        {
+          "paperId": "f9c09ef12d6967e0d9e840cf9db2806eec1bbcd1",
+          "title": "Support Vector Machines: Theory, Algorithms, and Applications"
+        },
+        {
+          "paperId": "e9c757171cd000cbe728ce009f5967afa4370a3d",
+          "title": "Evaluation of traditional machine learning algorithms for featuring educational exercises"
+        },
+        {
+          "paperId": "4e801a0934c9e40559c4efb9e21f50d9ec02d943",
+          "title": "Predictive Analysis of Student Performance using Machine Learning Models"
+        },
+        {
+          "paperId": "0652427935d4bf4f3f372932aa9347c40ac0d66d",
+          "title": "A mathematical perspective of machine learning"
+        },
+        {
+          "paperId": "7345f794a9b0a100b8798bf486ae8b8aae41786e",
+          "title": "Foundations, Techniques, Algorithms and Tools for Integrating Learning, Reasoning and Optimisation"
+        },
+        {
+          "paperId": "90d8fa3c01c602b2a3ad0d831f284eeb35cae5bd",
+          "title": "Predictive Model to Analyse Real and Synthetic Data for Learners' Performance Prediction Using Regression Techniques"
+        },
+        {
+          "paperId": "5f5c96f29f015e88ef8be0b7ceeb77275754250a",
+          "title": "A three-stage machine learning and inference approach for educational data"
+        },
+        {
+          "paperId": "76189670baa3190295d1b520ddfaef40a9451f27",
+          "title": "Analyzing the Performance of SVM and KNN in Supervised Learning for Classification"
+        }
+      ]
+    },
+    {
+      "paperId": "2e5d2f2dc01b150dffc163a9f457848e9b5b5c38",
+      "title": "On Hyperparameter Optimization of Machine Learning Algorithms: Theory and Practice",
+      "recommendations": [
+        {
+          "paperId": "e64c3cc2aab49ff985c2449d55ba63e19fa1c53c",
+          "title": "Bayesian Optimization for Simultaneous Selection of Machine Learning Algorithms and Hyperparameters on Shared Latent Space"
+        },
+        {
+          "paperId": "0583ba6d9648686f8cc1b53139addd4dadffc7ae",
+          "title": "Optimization Techniques in Machine Learning: Mathematical Models and Applications"
+        },
+        {
+          "paperId": "41b0d124aae9455bb80705d54b03a0736e15d4c3",
+          "title": "Optimizing deep learning models from multi-objective perspective via Bayesian optimization"
+        },
+        {
+          "paperId": "20ffac3c8e907dbbf4421a248f849c92259f01df",
+          "title": "PurGE: Towards Responsible Artificial Intelligence Through Sustainable Hyperparameter Optimization"
+        },
+        {
+          "paperId": "ec6c3bbae79248039b602acc78ed32b1025df8ef",
+          "title": "Multi-Criteria Method for Comparing the Effectiveness of Gradient Descent Modifications on Benchmark Functions"
+        },
+        {
+          "paperId": "e8df6b73cc3e329c1857980e697f59ff697dd3cd",
+          "title": "Optimizing Neural Network Performance Through Adaptive Learning Algorithms"
+        },
+        {
+          "paperId": "31d3302829a88d8393b55816e1b93a2e68d5e85e",
+          "title": "Optimization Techniques in Machine Learning: A Comprehensive Review"
+        },
+        {
+          "paperId": "7dbedaf868c1f9baabb6c7cf5d98f962480e1271",
+          "title": "A Review on the Impact of Evolutionary Optimization Algorithms in Enhancing Learning Processes"
+        },
+        {
+          "paperId": "40fd35c3949c14ea175c5629ed39149d61ee2828",
+          "title": "On the Convergence of Adam-Type Algorithm for Bilevel Optimization under Unbounded Smoothness"
+        },
+        {
+          "paperId": "2cdecba710a60df3cbc5bea2649f7ac3c1962238",
+          "title": "Training neural networks faster with minimal tuning using pre-computed lists of hyperparameters for NAdamW"
+        },
+        {
+          "paperId": "8ecbdc1adcd7223db9849bf926eb47b4434fd624",
+          "title": "Optimizing ML Training with Metagradient Descent"
+        },
+        {
+          "paperId": "ee2de2a446db2eb670ce1933eca072499b0cef89",
+          "title": "Accelerating Neural Network Training: An Analysis of the AlgoPerf Competition"
+        },
+        {
+          "paperId": "1090b0bd3c8734e571b126f8403128f2d8c7d9ef",
+          "title": "Meta-learning Population-based Methods for Reinforcement Learning"
+        },
+        {
+          "paperId": "e0f9e5f3681cc712d466a486f3656d8b5f4c33ba",
+          "title": "Grouped Sequential Optimization Strategy -- the Application of Hyperparameter Importance Assessment in Deep Learning"
+        },
+        {
+          "paperId": "3b83976f4bbdb3cbe4b097d0958d679bec49f547",
+          "title": "MODELLING AND ANALYSIS OF OPTIMIZATION ALGORITHMS"
+        },
+        {
+          "paperId": "94161b0ccc8e99be01a5a2e730a3bee9926ac0be",
+          "title": "HyperArm Bandit Optimization: A Novel approach to Hyperparameter Optimization and an Analysis of Bandit Algorithms in Stochastic and Adversarial Settings"
+        },
+        {
+          "paperId": "db25a21ebfbd39254cf1f6403993604d263ab65b",
+          "title": "A Comparative Study of Optimization Techniques in Deep Learning Using the MNIST Dataset"
+        },
+        {
+          "paperId": "ef25cc22c4341460a3afbf2c3ae1330d1789f359",
+          "title": "Scaling Up Optuna: P2P Distributed Hyperparameters Optimization"
+        },
+        {
+          "paperId": "39af6b6a887aeb0790315bffd5a6b20fa0a43a9e",
+          "title": "RBFleX-NAS: Training-Free Neural Architecture Search Using Radial Basis Function Kernel and Hyperparameter Detection"
+        },
+        {
+          "paperId": "630506998043fd51e11cde2ad6363ed665a2a499",
+          "title": "Model Selection for Off-policy Evaluation: New Algorithms and Experimental Protocol"
+        }
+      ]
+    },
+    {
+      "paperId": "0b40b4c631e3bfe8211c1529168029df7ad2e8e8",
+      "title": "Retiring Adult: New Datasets for Fair Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "f88236c6fe4b504cef364222cd88de3da84db8fb",
+          "title": "Fair Sufficient Representation Learning"
+        },
+        {
+          "paperId": "c1dc05b322ff5f7bd784d056920772de9ed55b7d",
+          "title": "Exploration of Potential New Benchmark for Fairness Evaluation in Europe"
+        },
+        {
+          "paperId": "3980bd94e9e1f54c0366a4ef003b4866cb2b44f0",
+          "title": "FaAlGrad: Fairness through Alignment of Gradients across Different Subpopulations"
+        },
+        {
+          "paperId": "c2f21a8dbdc136f081f14b40bfe69c41f9975d70",
+          "title": "Transfer Learning of CATE with Kernel Ridge Regression"
+        },
+        {
+          "paperId": "db9d467f153856450c02f8c5b8cc07241aad596b",
+          "title": "Active Data Sampling and Generation for Bias Remediation"
+        },
+        {
+          "paperId": "5b3931747b2113d51ffc2cdbfcfd61f4fcd595fd",
+          "title": "Fair Learning by Model Averaging (Revised Version)"
+        },
+        {
+          "paperId": "d196ff3e4c6adf622b7724659656e7694b1a34f3",
+          "title": "Uncovering Fairness through Data Complexity as an Early Indicator"
+        },
+        {
+          "paperId": "53a0bac11eee69dd2f95f683fb7851117c4f99d0",
+          "title": "From Laws to Algorithms: Detecting Unfairness in Machine Learning Models"
+        },
+        {
+          "paperId": "91ce4e6ad8eb5227744df0f6c8e2bf4fd8d1d883",
+          "title": "Explaining Fairness Violations using Machine Unlearning"
+        },
+        {
+          "paperId": "a0fd5ca02894cb51add87f2f23c4c6e794337f2b",
+          "title": "EquiPy: Sequential Fairness using Optimal Transport in Python"
+        },
+        {
+          "paperId": "4846f7ed2f3c657ce88fad2ab926af9c1467f352",
+          "title": "Sample Weight Averaging for Stable Prediction"
+        },
+        {
+          "paperId": "fc38f3e60ee4e79437bee9186bebcd6e7165b096",
+          "title": "Is Elo Rating Reliable? A Study Under Model Misspecification"
+        },
+        {
+          "paperId": "22e00044976f3ae97afef9be06e411f29ca5d527",
+          "title": "Machine Learning Should Maximize Welfare, Not (Only) Accuracy"
+        },
+        {
+          "paperId": "a38a6f445a66c2d2255c0e718195e6f573921c47",
+          "title": "Multiaccuracy and Multicalibration via Proxy Groups"
+        },
+        {
+          "paperId": "9427649338f55ca6fe1257370e0e1fc8de6e67f9",
+          "title": "Rethinking Robustness in Machine Learning: A Posterior Agreement Approach"
+        },
+        {
+          "paperId": "0cc6a66e3ba491827ab67808cee26bc313457745",
+          "title": "Empirical Comparison of Post-processing Debiasing Methods for Machine Learning Classifiers in Healthcare"
+        },
+        {
+          "paperId": "bf38aba9a2b03528b29fde58dc1763cf7cb44d86",
+          "title": "DUPRE: Data Utility Prediction for Efficient Data Valuation"
+        },
+        {
+          "paperId": "7bbd7ec1d7837d0aa6d75a79ac07ef329eb4f0b9",
+          "title": "Emerging algorithmic bias: fairness drift as the next dimension of model maintenance and sustainability."
+        },
+        {
+          "paperId": "355cb16eca779be708a6346f69535214666fc4b4",
+          "title": "Learning: An Experimental Evaluation on Aggregation Algorithms"
+        },
+        {
+          "paperId": "9e90796e971a31f10be4a23ddff894f4fef8243b",
+          "title": "Towards Large Language Models that Benefit for All: Benchmarking Group Fairness in Reward Models"
+        }
+      ]
+    },
+    {
+      "paperId": "a4f9e7e695bba1ffb90b30752a40d5ee907dcb36",
+      "title": "Pervasive Label Errors in Test Sets Destabilize Machine Learning Benchmarks",
+      "recommendations": [
+        {
+          "paperId": "959980f1824b7e0e7da71798481621e20508f24e",
+          "title": "phepy: Visual Benchmarks and Improvements for Out-of-Distribution Detectors"
+        },
+        {
+          "paperId": "c9d8fb0ebbc07ddd7a79a5480fb7a0cc384759f5",
+          "title": "Robust Partial-Label Learning by Leveraging Class Activation Values"
+        },
+        {
+          "paperId": "d700d6df4729414d579172e5ce83ea9bfca4a062",
+          "title": "Using samples with label noise for robust continual learning."
+        },
+        {
+          "paperId": "121ef6b3783c6f3d83d07cd2e07a1d2fbea3e097",
+          "title": "Noisy Label Learning with Instance-Dependent Outliers: Identifiability via Crowd Wisdom"
+        },
+        {
+          "paperId": "1ca5fbe256fac70d0776b80d677385419b332cbb",
+          "title": "Correcting Noisy Multilabel Predictions: Modeling Label Noise through Latent Space Shifts"
+        },
+        {
+          "paperId": "a8d3e8dd502b2ee86e6d4eb720ab92e1a530c21f",
+          "title": "Identifying and Mitigating Label Noise in Deep Learning for Image Classification"
+        },
+        {
+          "paperId": "73e5d17f74364c265e42cf50a28ef6510dd827d6",
+          "title": "FILM: Framework for Imbalanced Learning Machines based on a new unbiased performance measure and a new ensemble-based technique"
+        },
+        {
+          "paperId": "c8be9915034d76a7be10a93f40c44ccf957c3ad3",
+          "title": "The Accuracy Cost of Weakness: A Theoretical Analysis of Fixed-Segment Weak Labeling for Events in Time"
+        },
+        {
+          "paperId": "5f86d7eceb49cbd7e4bf66625e43ab8592442ee6",
+          "title": "TMLC-Net: Transferable Meta Label Correction for Noisy Label Learning"
+        },
+        {
+          "paperId": "cdb7c2788902b570d3a79b6fd9d31b1b0a5e1ba2",
+          "title": "Enhancing Sample Selection by Cutting Mislabeled Easy Examples"
+        },
+        {
+          "paperId": "773a3ebef69664e1eed9d8dcfc9af8b66371bb4e",
+          "title": "The Majority Vote Paradigm Shift: When Popular Meets Optimal"
+        },
+        {
+          "paperId": "0f6d78420896a6f5cb396ccc73524af63e761b44",
+          "title": "Stacking Model‐Based Classifiers for Dealing With Multiple Sets of Noisy Labels"
+        },
+        {
+          "paperId": "794286ed135a1e879dd7c3040a08769cbc0d4f8f",
+          "title": "Are Domain Generalization Benchmarks with Accuracy on the Line Misspecified?"
+        },
+        {
+          "paperId": "90f6df0b6cd2b447c14dab05c630c04f76639f3d",
+          "title": "Unique Rashomon Sets for Robust Active Learning"
+        },
+        {
+          "paperId": "fc8152ec6fba4a7cb7c54ec0199ffb8db71c9b39",
+          "title": "Does Training on Synthetic Data Make Models Less Robust?"
+        },
+        {
+          "paperId": "e89f50fd4003e5a678f3257b7f873c87113acb19",
+          "title": "Challenging the Performance-Interpretability Trade-Off: An Evaluation of Interpretable Machine Learning Models"
+        },
+        {
+          "paperId": "6458cef9a4ac77b0432d23d4e86eea64c8ab326c",
+          "title": "Active Learning with a Noisy Annotator"
+        },
+        {
+          "paperId": "fab740cd33554a14d838a9193de326f2eee2424d",
+          "title": "Realistic Evaluation of Deep Partial-Label Learning Algorithms"
+        },
+        {
+          "paperId": "8c9795035c5245841f2f4ed3ee71bea931d24b13",
+          "title": "Unsupervised label generation for severely imbalanced fraud data"
+        },
+        {
+          "paperId": "99b049973f0cb477e50570b699f313e102ebd89f",
+          "title": "Self Iterative Label Refinement via Robust Unlabeled Learning"
+        }
+      ]
+    },
+    {
+      "paperId": "8ca86e941da7254613a5d03dd7a6c36886fadc1d",
+      "title": "Gaussian Processes for Machine Learning (Adaptive Computation and Machine Learning)",
+      "recommendations": [
+        {
+          "paperId": "3c858168d4fb69d62744516d987c05fd3def5343",
+          "title": "Bayesian Methods in Machine Learning Applications and Challenges"
+        },
+        {
+          "paperId": "1bb7236631e798da6ea9cc4bc795612162f930e9",
+          "title": "Optimal Kernel Learning for Gaussian Process Models with High-Dimensional Input"
+        },
+        {
+          "paperId": "9e095293833d56d5b047724add2339703b9ccac2",
+          "title": "Distributionally Robust Active Learning for Gaussian Process Regression"
+        },
+        {
+          "paperId": "9043209f5501b73fa99ea22c524c229604201e08",
+          "title": "HiGP: A high-performance Python package for Gaussian Process"
+        },
+        {
+          "paperId": "60c5e411247e046e4b2e8f95caf643303ecf8cb1",
+          "title": "Scaling Law for Stochastic Gradient Descent in Quadratically Parameterized Linear Regression"
+        },
+        {
+          "paperId": "6334f4ab323f753986535b2ad4cb22f1f7cf3983",
+          "title": "Enhancing Naive Bayes Algorithm with Stable Distributions for Classification"
+        },
+        {
+          "paperId": "8bb47b5cc7eb73af5886f8f95dba5559753e28b8",
+          "title": "EarlyStopping: Implicit Regularization for Iterative Learning Procedures in Python"
+        },
+        {
+          "paperId": "923c698ffdcf023a892c2ec48f43710b4411e4ac",
+          "title": "Bayesian Kernel Regression for Functional Data"
+        },
+        {
+          "paperId": "1997ca1fd12b3c3f7ab7c99872460569e820199d",
+          "title": "Mixture models for data with unknown distributions"
+        },
+        {
+          "paperId": "1c72d10b7fa6618f867e617db2525800a830bcaf",
+          "title": "A Deep Dive into Training Algorithms for Deep Belief Networks"
+        },
+        {
+          "paperId": "3e9941ea628e9990252b1142470410fb0241e823",
+          "title": "SEEK: Self-adaptive Explainable Kernel For Nonstationary Gaussian Processes"
+        },
+        {
+          "paperId": "818c0bf0cc6f15a7edc20a11e30a267436a72ddf",
+          "title": "Computational Statistics and Data Analysis"
+        },
+        {
+          "paperId": "b18dcb4956347f9ad05e828ad1303940ddbe6403",
+          "title": "Learning sparse generalized linear models with binary outcomes via iterative hard thresholding"
+        },
+        {
+          "paperId": "0652427935d4bf4f3f372932aa9347c40ac0d66d",
+          "title": "A mathematical perspective of machine learning"
+        },
+        {
+          "paperId": "eaa3cfee2c9d6f50daee36f24023bc48ab1b7fd6",
+          "title": "Bayesian estimation of a multivariate TAR model when the noise process distribution belongs to the class of Gaussian variance mixtures"
+        },
+        {
+          "paperId": "552375feaab401aeba301375bd7de659ac2b4104",
+          "title": "Learning local neighborhoods of non-Gaussian graphical models: A measure transport approach"
+        },
+        {
+          "paperId": "36d9f1ce17d2e5b8e119158357eba96e916eb363",
+          "title": "Negative Dependence as a toolbox for machine learning : review and new developments"
+        },
+        {
+          "paperId": "2a2e22044ab675b30de253b92f96f782247775df",
+          "title": "A quantum gradient descent algorithm for optimizing Gaussian Process models"
+        },
+        {
+          "paperId": "fae6cb46240a790492ec8c01cada0c782bdefb3a",
+          "title": "Optimal Algorithms in Linear Regression under Covariate Shift: On the Importance of Precondition"
+        },
+        {
+          "paperId": "89104f37cbc9e0ec2afc614d5fda67584ca9f709",
+          "title": "Sparse Gaussian Neural Processes"
+        }
+      ]
+    },
+    {
+      "paperId": "20f63033e8775cbab0692aed92d38da7e725d64e",
+      "title": "Understanding Machine Learning - From Theory to Algorithms",
+      "recommendations": [
+        {
+          "paperId": "92e77426658ee7505b18113b3c4c3c75923d8e8e",
+          "title": "A Review on Various Machine Learning Algorithms"
+        },
+        {
+          "paperId": "ce56e39852906b82326dae0173c0a5ab5c468821",
+          "title": "Algebraic Machine Learning: Learning as computing an algebraic decomposition of a task"
+        },
+        {
+          "paperId": "0652427935d4bf4f3f372932aa9347c40ac0d66d",
+          "title": "A mathematical perspective of machine learning"
+        },
+        {
+          "paperId": "6fdded27361a81dfe2a0072526e194aead29513b",
+          "title": "Machine Learning with Python"
+        },
+        {
+          "paperId": "f03a2855513adb48fec66f25825757811196cae7",
+          "title": "Computational Science and Engineering"
+        },
+        {
+          "paperId": "fdac022439554211a901800a92eefff0687aaad8",
+          "title": "A Comprehensive Overview of Machine Learning Models: Techniques, Applications, and Future Directions"
+        },
+        {
+          "paperId": "80f3c5f014037f22720c1aca5d0b52de138a51d3",
+          "title": "Sheaf theory: from deep geometry to deep learning"
+        },
+        {
+          "paperId": "132d4468c28b3d5bb372fc5a9c14f237076c2b2a",
+          "title": "Practical Topics in Optimization"
+        },
+        {
+          "paperId": "cc095c4c38cc5b8dca0052d99f484ddbd9ff7051",
+          "title": "Theory and Practice of Artificial Intelligence"
+        },
+        {
+          "paperId": "099bddaf1fc2c2c67000cebd812333abccb76470",
+          "title": "Machine Learned Force Fields: Fundamentals, its reach, and challenges"
+        },
+        {
+          "paperId": "e6fec9e68b0b3c71c843d56743645dc49b0bf346",
+          "title": "Generative Modeling for Mathematical Discovery"
+        },
+        {
+          "paperId": "f9c09ef12d6967e0d9e840cf9db2806eec1bbcd1",
+          "title": "Support Vector Machines: Theory, Algorithms, and Applications"
+        },
+        {
+          "paperId": "525b67a6fd74fc9a2ed93552b4fab482e36e2300",
+          "title": "Study of Machine Learning Algorithms: A Historical Perspective"
+        },
+        {
+          "paperId": "deca38d488e16db5d49f2ce85bdb78fa8db1e77a",
+          "title": "Understanding machine learning and its applications"
+        },
+        {
+          "paperId": "e30f9b924c63176d241ea831876cff779e6c16d6",
+          "title": "Dynamical Decoupling of Generalization and Overfitting in Large Two-Layer Networks"
+        },
+        {
+          "paperId": "c9da7b17476ddd4b357211674c29f0856a90658f",
+          "title": "The Evolution of Machine Learning Potentials for Molecules, Reactions and Materials"
+        },
+        {
+          "paperId": "3c858168d4fb69d62744516d987c05fd3def5343",
+          "title": "Bayesian Methods in Machine Learning Applications and Challenges"
+        },
+        {
+          "paperId": "9de58a0e71c1df4fc3bba8bdcbf442843250b162",
+          "title": "the idea behind the idea behind AdaGrad?"
+        },
+        {
+          "paperId": "1c72d10b7fa6618f867e617db2525800a830bcaf",
+          "title": "A Deep Dive into Training Algorithms for Deep Belief Networks"
+        },
+        {
+          "paperId": "c5666a6f87e5b511dce1a9da339a4b28aa827ad9",
+          "title": "Applications of Statistical Field Theory in Deep Learning"
+        }
+      ]
+    },
+    {
+      "paperId": "ab06951251e0abfdb866694f9a23a79c72784317",
+      "title": "Challenges and opportunities in quantum machine learning",
+      "recommendations": [
+        {
+          "paperId": "ae168840d3ff1d2b4b3920e3739307f7e2f55d4d",
+          "title": "Quantum Machine Learning: Bridging Quantum Computing and AI for Exponential Gains"
+        },
+        {
+          "paperId": "d18bd5a825c1efeab63b3d8f223fd1390d396774",
+          "title": "Exploring the Frontiers of Quantum Machine Learning: A New Era in AI and Computation"
+        },
+        {
+          "paperId": "4345cf3a7e8d314d33015f20bc287520f89b0d03",
+          "title": "Quantum-Enhanced Machine Learning: Harnessing Quantum Computing for Next-Generation AI Systems"
+        },
+        {
+          "paperId": "3a945475a738deecc3bba832b9d204acffb172d2",
+          "title": "Quantum AI: The future of machine learning and optimization"
+        },
+        {
+          "paperId": "ccf415878be02daf47f74a4acd9938badc989ac0",
+          "title": "Quantum minds: Merging quantum computing with next-gen AI"
+        },
+        {
+          "paperId": "5ae3ed0d0dc84754f3b75871d02b7d257d4d8c9f",
+          "title": "The Advantage and Disadvantage of Development of Quantum Computing in Machine Learning"
+        },
+        {
+          "paperId": "e09fe9d0fc3c1a941b12adf09ecd8574bf831fb2",
+          "title": "Qubit-Based Framework for Quantum Machine Learning: Bridging Classical Data and Quantum Algorithms"
+        },
+        {
+          "paperId": "652a6f9bd6de206133978a65369c56aa9c1e255a",
+          "title": "An Overview of Quantum Machine Learning Research in China"
+        },
+        {
+          "paperId": "5d4bfd28fff2a897124df7008bf2e4f00c8a31b7",
+          "title": "Quantum ensemble learning with a programmable superconducting processor"
+        },
+        {
+          "paperId": "2bd7ffbadd3ed9922fe19f1fd9acd1142e8cc5e8",
+          "title": "Machine Learning for Estimation and Control of Quantum Systems"
+        },
+        {
+          "paperId": "1fd5423e1282f39eb4a5b75dec07714f0f66ee9d",
+          "title": "Multiple Embeddings for Quantum Machine Learning"
+        },
+        {
+          "paperId": "39e7f35a4b8bba19c3e34721ef7867320e1bb01e",
+          "title": "Training Hybrid Deep Quantum Neural Network for Reinforced Learning Efficiently"
+        },
+        {
+          "paperId": "cdd425c36921888d7cb4836d1ee4299df66d4d55",
+          "title": "Parallelizing the stabilizer formalism for quantum machine learning applications"
+        },
+        {
+          "paperId": "f168ef23d369b873f7d9fb0e2f7eb7658920b2ef",
+          "title": "Quantum parallel information exchange (QPIE) hybrid network with transfer learning"
+        },
+        {
+          "paperId": "f9a292184449325be23d1260c43e89f0dfe68c34",
+          "title": "Meta-learning characteristics and dynamics of quantum systems"
+        },
+        {
+          "paperId": "dd1d43571625fdc2951b5db5a46be860fa5c284d",
+          "title": "Training Hybrid Deep Quantum Neural Network for Reinforcement Learning Efficiently"
+        },
+        {
+          "paperId": "a2f76be1cea873b23db15c0061ddeb51d1c2cd37",
+          "title": "Quantum Machine Learning: Bridging Quantum Computing and Artificial Intelligence."
+        },
+        {
+          "paperId": "c9a3e203a5e00a5c81021ea4f5fef30b994b8f39",
+          "title": "EXPLORING QUANTUM MACHINE LEARNING FOR ENHANCED DATA PROCESSING IN HIGH-DIMENSIONAL SPACES"
+        },
+        {
+          "paperId": "e14a8e48231a538236d2190514879d6c90fce454",
+          "title": "Entanglement-enabled quantum kernels for enhanced feature mapping"
+        },
+        {
+          "paperId": "165ae0bfe2b1c23d68a515605440a224f95a1c2b",
+          "title": "Quantum advantage for learning shallow neural networks with natural data distributions"
+        }
+      ]
+    },
+    {
+      "paperId": "d0ab11de3077490c80a08abd0fb8827bac84c454",
+      "title": "MoleculeNet: a benchmark for molecular machine learning",
+      "recommendations": [
+        {
+          "paperId": "271a22bd209c8eb6d2ebeb7b513a9add1a33a3e9",
+          "title": "GraphXForm: Graph transformer for computer-aided molecular design with application to extraction"
+        },
+        {
+          "paperId": "276a6564cecc0458ba62300088ffe907c30206a2",
+          "title": "Learning Chemical Intuition: From Molecular Models to Neural Networks"
+        },
+        {
+          "paperId": "671612edd28701c3110ce962bab1b06d07b4cb50",
+          "title": "Improving Reaction Prediction through Chemically Aware Transfer Learning"
+        },
+        {
+          "paperId": "c382b3ad736bf849f87895401f460e999743183e",
+          "title": "Accelerating materials property discovery in uncharted domains through the integration of high-throughput computation and machine learning"
+        },
+        {
+          "paperId": "5f997fef1da814b290147083d5a84be91f6d1993",
+          "title": "Harnessing the Leading Edge: Machine Learning Ventures in Chemistry and Materials Science"
+        },
+        {
+          "paperId": "b431d16e846dc2bcaebb83c93565ffb843352e80",
+          "title": "Can Large Language Models Predict the Hydrophobicity of Metal−Organic Frameworks?"
+        },
+        {
+          "paperId": "6ac95375feeedfebd36f637d2311d5e02dfec16d",
+          "title": "Accelerating the discovery of single-molecule magnets with deep learning"
+        },
+        {
+          "paperId": "5e2fc3ada1e6718150495c2b08bca2b36b37f786",
+          "title": "Investigating Structural Biophysical Features for Antigen-Binding Fragment Crystallization via Machine Learning"
+        },
+        {
+          "paperId": "66d0f8ca38a328e93fdb369fa5bfc01b413e957a",
+          "title": "TaxDiﬀ: taxonomic-guided diﬀusion model for protein sequence generation"
+        },
+        {
+          "paperId": "17a414a9f86fdc95d452a24b850456dee4fb2cf6",
+          "title": "High-throughput screening of high-activity oxygen carriers for chemical looping argon purification via a machine learning – density functional theory method"
+        },
+        {
+          "paperId": "784213b1869ab6ecd1e8b04050c73116668ee238",
+          "title": "A Machine Learning Assisted Design for Adjusting Solubility of Ibuprofen Related Binary Compounds: A Data Driven Approach"
+        },
+        {
+          "paperId": "730c9ca091a887bf63bbbd69af958153078062e5",
+          "title": "DOPtools: a Python platform for descriptor calculation and model optimization"
+        },
+        {
+          "paperId": "f2cba1be841ef9ff8f4145ffc210da355f9ab771",
+          "title": "Computational Discovery and Systematic Analysis of Protein Entangling Motifs in Nature: From Algorithm to Database"
+        },
+        {
+          "paperId": "74fa3a287e0a57527a3621aebc0f21a71e214439",
+          "title": "h3ppy: An open-source Python package for modelling and fitting H_3^+ spectra"
+        },
+        {
+          "paperId": "d42a9875d70808c4d835ba8288bc3026f2337b57",
+          "title": "Physics and machine learning: mutual benefits"
+        },
+        {
+          "paperId": "5d2a17b42308b4bb27bfc82b7137050e9af40754",
+          "title": "Computer-Aided Drug Design and Drug Discovery"
+        },
+        {
+          "paperId": "89af85c86b8bdfcc3bd04d6d0472bf3e1662437b",
+          "title": "IMPRESSION Generation 2 – Accurate, fast and generalised neural network model for predicting NMR parameters in place of DFT."
+        },
+        {
+          "paperId": "84a36417fe1e5ff0ccdeb531e0d304d6df62d1c0",
+          "title": "Charge-driven stability and aromaticity of C₂N₂B₂H₄ isomers: Insights from a combined DFT and machine learning study"
+        },
+        {
+          "paperId": "2775857c99237f18cb6ee40c8cb7c17eaa574b3d",
+          "title": "Machine learning assisted designing of compounds with higher glass transition temperature. Chemical Space Visualization and synthetic accessibility determination"
+        },
+        {
+          "paperId": "44e8350374789c97059bf5d267216b1dfb56a694",
+          "title": "Unveiling CO2 reactivity with data-driven methods"
+        }
+      ]
+    },
+    {
+      "paperId": "4087e84fc695bb6433d0104ee94f9d7e9f4b7da5",
+      "title": "Machine Learning for Fluid Mechanics",
+      "recommendations": [
+        {
+          "paperId": "668c75d528d7a377ae06f4f9ade567d747128a27",
+          "title": "A Review of Simulations and Machine Learning Approaches for Flow Separation Analysis"
+        },
+        {
+          "paperId": "fc20da60a634e5091c5bb0629d9ec2e304376a64",
+          "title": "Machine learning for modelling unstructured grid data in computational physics: a review"
+        },
+        {
+          "paperId": "392c5b0819ad935e4e075248d265e5c3762ef1b0",
+          "title": "Automated Machine Learning For Computational Mechanics (Dagstuhl Seminar 24282)"
+        },
+        {
+          "paperId": "152995395ffbbf5268ea16e337d8937431129873",
+          "title": "Mathematical Modeling for Machine Learning: Theory, Simulation, and Scientific Computing"
+        },
+        {
+          "paperId": "bf023a60430775b7c8725f5ef51aee635e8b19fb",
+          "title": "Machine-learning heat flux closure for multi-moment fluid modeling of nonlinear Landau damping."
+        },
+        {
+          "paperId": "b109e446960502d6e7a26b9948b02a2eda79458b",
+          "title": "Learning Effective Dynamics across Spatio-Temporal Scales of Complex Flows"
+        },
+        {
+          "paperId": "48b0662c8a6b3c8d85b8028c377899a844a2c07c",
+          "title": "Statistical machine learning tools for probabilistic closures of turbulence models"
+        },
+        {
+          "paperId": "11b2757dc3a1124ef5b9bd43c73a2e8e28fd877b",
+          "title": "PINP: Physics-Informed Neural Predictor with latent estimation of fluid flows"
+        },
+        {
+          "paperId": "2ea0191eee8ef4c5245f551814163a42c2baabc3",
+          "title": "Advancements in Thermodynamic Modeling: Bridging Classical Theory and Computational Techniques"
+        },
+        {
+          "paperId": "0f4ace1bc06afe9a6501bf94cf92823e10798013",
+          "title": "PIMRL: Physics-Informed Multi-Scale Recurrent Learning for Spatiotemporal Prediction"
+        },
+        {
+          "paperId": "099bddaf1fc2c2c67000cebd812333abccb76470",
+          "title": "Machine Learned Force Fields: Fundamentals, its reach, and challenges"
+        },
+        {
+          "paperId": "4857760191a2ed07bac5dae51936772cb704e90e",
+          "title": "Machine learning stochastic dynamics"
+        },
+        {
+          "paperId": "40b999ada6cc3c74a4154c3cd2c158456e3b65d9",
+          "title": "Toward human-interpretable, automated learning of feedback control for the mixing layer"
+        },
+        {
+          "paperId": "c59320583c72493ace030a5d6a3ef8b5ef072947",
+          "title": "Curriculum Learning-Driven PIELMs for Fluid Flow Simulations"
+        },
+        {
+          "paperId": "7bffe620778a811fe6e63163e390555b6d8d8682",
+          "title": "Force-Free Molecular Dynamics Through Autoregressive Equivariant Networks"
+        },
+        {
+          "paperId": "40482f69ce1efe3317c4a4a97c0937b8c69ebd90",
+          "title": "Crash testing machine learning force fields for molecules, materials, and interfaces: model analysis in the TEA Challenge 2023"
+        },
+        {
+          "paperId": "c43c831175ff586983886ab16662f65c575aa591",
+          "title": "Dimensional analysis meets AI for non-Newtonian droplet generation"
+        },
+        {
+          "paperId": "267acda75ed749055aa589531f1f83f5bd474c2b",
+          "title": "Physics-informed neural networks for hidden boundary detection and flow field reconstruction"
+        },
+        {
+          "paperId": "68da0955d23e1b5e4f23913bdf4d241ed8d0afb5",
+          "title": "Operator Learning: A Statistical Perspective"
+        },
+        {
+          "paperId": "40bc222d97c3f7c3835444bdcb2ee1b9ba77e8c2",
+          "title": "Learning Distributions of Complex Fluid Simulations with Diffusion Graph Networks"
+        }
+      ]
+    },
+    {
+      "paperId": "256db9dba1978f004a67c86ffc321563b1aee79a",
+      "title": "Interpretable Machine Learning: Fundamental Principles and 10 Grand Challenges",
+      "recommendations": [
+        {
+          "paperId": "b582dbd7b4dc1cb02623e6168a7581c5411c2c6c",
+          "title": "Learning Ensembles of Interpretable Simple Structure"
+        },
+        {
+          "paperId": "e89f50fd4003e5a678f3257b7f873c87113acb19",
+          "title": "Challenging the Performance-Interpretability Trade-Off: An Evaluation of Interpretable Machine Learning Models"
+        },
+        {
+          "paperId": "7934d9a8ad67cf81172590bcbe44e9a9aba24f9b",
+          "title": "Sample-efficient Learning of Concepts with Theoretical Guarantees: from Data to Concepts without Interventions"
+        },
+        {
+          "paperId": "c036889fa66d70a4e98da5187a13acb189f6bb8a",
+          "title": "The Rise of Explainable AI: Trends in Interpretability for Machine Learning Models"
+        },
+        {
+          "paperId": "9e31e576818a6939ded6f78e2e5181301f1ca3fe",
+          "title": "Green LIME: Improving AI Explainability through Design of Experiments"
+        },
+        {
+          "paperId": "bf51f5eef7ed6b8a07f1326ee490ed8891f9667a",
+          "title": "Meta-Statistical Learning: Supervised Learning of Statistical Inference"
+        },
+        {
+          "paperId": "d293115703f921708a80dbccaa8e5dffcc126af3",
+          "title": "Explainability in AI: Interpretable Models for Data Science"
+        },
+        {
+          "paperId": "377588aa6fe6d161d1f52aa10eff61985993c4d1",
+          "title": "Interpretable Feature Interaction via Statistical Self-supervised Learning on Tabular Data"
+        },
+        {
+          "paperId": "d0fd6eacce00579a95ebdbc69f227774cee349ab",
+          "title": "The Clever Hans Effect in Unsupervised Learning"
+        },
+        {
+          "paperId": "361723f56800384f37e3dfe567fd2e7d3064fb2d",
+          "title": "Amortized Conditional Independence Testing"
+        },
+        {
+          "paperId": "7a5001c81e979080bed63fa62121b8d4e7098658",
+          "title": "Explainable AI (XAI): Methods and Techniques to Make Deep Learning Models More Interpretable and Their Real-World Implications"
+        },
+        {
+          "paperId": "c6a9edbfb61cf40cf9b3398491069e4fd7d66384",
+          "title": "Unsupervised Representation Learning in Deep Reinforcement Learning: A Review"
+        },
+        {
+          "paperId": "c48c744e57f20566c306752aba6b5a5714074713",
+          "title": "Additive Model Boosting: New Insights and Path(ologie)s"
+        },
+        {
+          "paperId": "f20c9bf80fbf4eba202d2e395c9aa0128477a5a9",
+          "title": "Models That Are Interpretable But Not Transparent"
+        },
+        {
+          "paperId": "cb3026a826551ae2ef2b204ebf5414c876584c04",
+          "title": "Enhancing Performance of Explainable AI Models with Constrained Concept Refinement"
+        },
+        {
+          "paperId": "f9fd55c01bf63749c7e0ed0543a3ecd56d6fd038",
+          "title": "Neural Approaches to SAT Solving: Design Choices and Interpretability"
+        },
+        {
+          "paperId": "d7beaccc2744df0166531e6c4d899e608d4b69d1",
+          "title": "Comparative study of neural nets and graphical models for causality and interpretability on the same dataset"
+        },
+        {
+          "paperId": "bc0fdcf8392a7bf861dc07d562ecdfc0c08e3ec1",
+          "title": "Learning Decision Trees as Amortized Structure Inference"
+        },
+        {
+          "paperId": "89104f37cbc9e0ec2afc614d5fda67584ca9f709",
+          "title": "Sparse Gaussian Neural Processes"
+        },
+        {
+          "paperId": "be79d0ef6dec980140bf3dc940a80a23183acf91",
+          "title": "HyperDAS: Towards Automating Mechanistic Interpretability with Hypernetworks"
+        }
+      ]
+    },
+    {
+      "paperId": "cf5dfc4a9f7a82b32640128ca10832eace55880e",
+      "title": "Quantum machine learning models are kernel methods",
+      "recommendations": [
+        {
+          "paperId": "93e47e95b5cf1288fff04118a582d5dea45549ce",
+          "title": "Digital-Analog Quantum Machine Learning"
+        },
+        {
+          "paperId": "8f5c187bb2540163a18a6c8d22782a76eb1fec09",
+          "title": "Enhancing variational quantum algorithms by balancing training on classical and quantum hardware"
+        },
+        {
+          "paperId": "62e4d5aa2eb5d83922c3aebdaf1f2ef68d6ef599",
+          "title": "Benign Overfitting with Quantum Kernels"
+        },
+        {
+          "paperId": "165ae0bfe2b1c23d68a515605440a224f95a1c2b",
+          "title": "Quantum advantage for learning shallow neural networks with natural data distributions"
+        },
+        {
+          "paperId": "39e7f35a4b8bba19c3e34721ef7867320e1bb01e",
+          "title": "Training Hybrid Deep Quantum Neural Network for Reinforced Learning Efficiently"
+        },
+        {
+          "paperId": "cefa32f19695fc66b12e5e9c638543bc4d9beed8",
+          "title": "Quantum-Efficient Kernel Target Alignment"
+        },
+        {
+          "paperId": "5ae3ed0d0dc84754f3b75871d02b7d257d4d8c9f",
+          "title": "The Advantage and Disadvantage of Development of Quantum Computing in Machine Learning"
+        },
+        {
+          "paperId": "fe8fd899c33c8e870e4d8f8c9f95ec8b0be98bfa",
+          "title": "Train on classical, deploy on quantum: scaling generative quantum machine learning to a thousand qubits"
+        },
+        {
+          "paperId": "bdf657309643156683242e907d9a9fd9e97c3b67",
+          "title": "Enhanced natural parameterized quantum circuit"
+        },
+        {
+          "paperId": "a0b30338c63d925fefbfc01ce9b78e27acf41dab",
+          "title": "Probabilistic Quantum SVM Training on Ising Machine"
+        },
+        {
+          "paperId": "f9a292184449325be23d1260c43e89f0dfe68c34",
+          "title": "Meta-learning characteristics and dynamics of quantum systems"
+        },
+        {
+          "paperId": "faa61af19772d8b051a19fc6e947f38177d19b76",
+          "title": "A randomized transformation for data processing on quantum computers"
+        },
+        {
+          "paperId": "76427c0692a076192fcde539139500c4c166c153",
+          "title": "The Impact of Architecture and Cost Function on Dissipative Quantum Neural Networks"
+        },
+        {
+          "paperId": "e09fe9d0fc3c1a941b12adf09ecd8574bf831fb2",
+          "title": "Qubit-Based Framework for Quantum Machine Learning: Bridging Classical Data and Quantum Algorithms"
+        },
+        {
+          "paperId": "59f906fb6c84ef62804f00f34a1f6e5c6db2dce1",
+          "title": "Quantum phase classification via quantum hypothesis testing"
+        },
+        {
+          "paperId": "292263dde6ae08ed2261a52cec715b188cc145f4",
+          "title": "Expressive equivalence of classical and quantum restricted Boltzmann machines"
+        },
+        {
+          "paperId": "399c7b669ff79e776125d8b268975863e6d4322c",
+          "title": "On Quantum Perceptron Learning via Quantum Search"
+        },
+        {
+          "paperId": "dd1d43571625fdc2951b5db5a46be860fa5c284d",
+          "title": "Training Hybrid Deep Quantum Neural Network for Reinforcement Learning Efficiently"
+        },
+        {
+          "paperId": "1825752ce2e8fef5af51553dec47d08a6eaf8b69",
+          "title": "DEVELOPMENT OF HYBRID QUANTUM-CLASSICAL MODELS FOR COMPUTER VISION"
+        },
+        {
+          "paperId": "ccf415878be02daf47f74a4acd9938badc989ac0",
+          "title": "Quantum minds: Merging quantum computing with next-gen AI"
+        }
+      ]
+    }
+  ],
+  "information retrieval": [
+    {
+      "paperId": "08fb24d7e57db7de0da428676b1a0a6903051442",
+      "title": "Doubly Efficient Private Information Retrieval and Fully Homomorphic RAM Computation from Ring LWE",
+      "recommendations": [
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "c1fd692ced2db5f2f08d2f04c39c941e4a992161",
+          "title": "Labeled Private Set Intersection From Distributed Point Function"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "8d17b38e0663c2e90d3b953d2699a16c9ee2cbfc",
+          "title": "Bandwidth-Efficient Two-Server ORAMs with O(1) Client Storage"
+        },
+        {
+          "paperId": "e9ffc414265b7509d873bdc81d028e3e9960b40b",
+          "title": "Non-interactive Anonymous Tokens with Private Metadata Bit"
+        },
+        {
+          "paperId": "6fd850392b509e63582a925cb8ab822568a557af",
+          "title": "Multi-party probabilistic quantum homomorphic encryption scheme based on Brown state"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "8e8e785856d7af05ad5db7e46a0a84b2c091ac11",
+          "title": "Femur: A Flexible Framework for Fast and Secure Querying from Public Key-Value Store"
+        },
+        {
+          "paperId": "a19ec57277b1265085aa0dcaeee17b2ef7ea9969",
+          "title": "Sublinear-Overhead Secure Linear Algebra on a Dishonest Server"
+        },
+        {
+          "paperId": "afdbb5081e28a45406bd3e990c9b95399369d519",
+          "title": "Verifiable Computation for Approximate Homomorphic Encryption Schemes"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "bd80748ae93b3915d7c137e5557838b0d39adb6b",
+          "title": "OBIR-tree: An Efficient Oblivious Index for Spatial Keyword Queries on Secure Enclaves"
+        },
+        {
+          "paperId": "b17bd5ca58e57d9ab85cd9aee3a1ff1d30abc46e",
+          "title": "PAEWS: Public-Key Authenticated Encryption With Wildcard Search Over Outsourced Encrypted Data"
+        },
+        {
+          "paperId": "de641d51e2129aca70f53193f547d26437a32262",
+          "title": "Trapdoor Hash Functions and PIR from Low-Noise LPN"
+        },
+        {
+          "paperId": "a8fbfacbca2cd356274b95f48c567e5ab51c19c1",
+          "title": "Practical Circuit Privacy/Sanitization for TFHE"
+        },
+        {
+          "paperId": "09b73fe067ef51d335bc182675a352c997f09491",
+          "title": "Veriﬁable Secret Sharing Based on Fully Batchable Polynomial Commitment for Privacy-Preserving Distributed Computation"
+        },
+        {
+          "paperId": "64dffdec8bc838d1a25871802c2f67d4155a8b21",
+          "title": "Beyond Access Pattern: Efficient Volume-Hiding Multi-Range Queries Over Outsourced Data Services"
+        }
+      ]
+    },
+    {
+      "paperId": "f00fc5531564aef9205104dec31fe25c94e6b4ea",
+      "title": "Deceptive Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "c17dc5a48d99465a08785e24c553c0a980a131e6",
+          "title": "Natural Language Processing for Improving Search Query Results"
+        },
+        {
+          "paperId": "7a76b13c94f7f74ab50bab93537902155c7f7e68",
+          "title": "Probabilistic analysis of data structures for locality-sensitive hashing functions"
+        },
+        {
+          "paperId": "3641d605893dd58816031bebc0a409b062d86552",
+          "title": "QUERY AND RETRIEVAL SYSTEM FOR TERRORISM DATABASE"
+        },
+        {
+          "paperId": "96f8c0c08ae8553e463cb6905e2b2c417712ae25",
+          "title": "Enhancement of Query Refinement for Marathi Language Information Retrieval"
+        },
+        {
+          "paperId": "88b814a9eef9ff9325f07888dd596dd37c82c94e",
+          "title": "A Query-Driven Approach to Space-Efficient Range Searching"
+        },
+        {
+          "paperId": "9744a4a086a39eda0f61ebe4302fc8105dc0b270",
+          "title": "Graph-Based Algorithms for Diverse Similarity Search"
+        },
+        {
+          "paperId": "874b6e2b2933c7d563c16b9597bb579bf1ed3263",
+          "title": "Information Theory Strikes Back: New Development in the Theory of Cardinality Estimation"
+        },
+        {
+          "paperId": "554a489e0fc5387f8440da193b99738c41a13acb",
+          "title": "Probabilistic Reasoning with LLMs for k-anonymity Estimation"
+        },
+        {
+          "paperId": "9312a587c8c95445ec4a5d9389ff844ee4465fd9",
+          "title": "Range Retrieval with Graph-Based Indices"
+        },
+        {
+          "paperId": "b0bdc30101f7a808cd25d1fbbdd74bd9003c5b09",
+          "title": "Saving Storage Space Using Files on the Web"
+        },
+        {
+          "paperId": "2d6f0f38e7b568f94f45767481bf21fbb175f197",
+          "title": "Property Testing of Curve Similarity"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "2f0a6d968e3756cf71ac8c07b8f7b3a9c6e27449",
+          "title": "Conversion of Unstructured File to Structured File in Cloud Computing"
+        },
+        {
+          "paperId": "b4f3f55867217876c970ea46714df805a611a4ce",
+          "title": "In-Place Updates of a Graph Index for Streaming Approximate Nearest Neighbor Search"
+        },
+        {
+          "paperId": "a3109694cb4ee112d2c94360af9976306524b968",
+          "title": "Comparative Analysis of Page Ranking Algorithms for Efficient Information Retrieval"
+        },
+        {
+          "paperId": "41b1e102fae3575583e1f9b8fb63becc5577605d",
+          "title": "Differential Privacy"
+        }
+      ]
+    },
+    {
+      "paperId": "9af8bccf3e42996cbb198a6ceccafa2a084689f6",
+      "title": "HybridRAG: Integrating Knowledge Graphs and Vector Retrieval Augmented Generation for Efficient Information Extraction",
+      "recommendations": [
+        {
+          "paperId": "bb73fbee40cd09431b53a1a6b958b41f6701d8c4",
+          "title": "Talking to GDELT Through Knowledge Graphs"
+        },
+        {
+          "paperId": "3c22ea27cac88f9dbb4ea08fbdf44a1d9777978c",
+          "title": "Pseudo-Knowledge Graph: Meta-Path Guided Retrieval and In-Graph Text for RAG-Equipped LLM"
+        },
+        {
+          "paperId": "00e92a3b206b7acb75ddb6dfc5fdaa80190cec78",
+          "title": "PathRAG: Pruning Graph-based Retrieval Augmented Generation with Relational Paths"
+        },
+        {
+          "paperId": "d500f728daff3a345d945887f436a25c2a78eb91",
+          "title": "ArchRAG: Attributed Community-based Hierarchical Retrieval-Augmented Generation"
+        },
+        {
+          "paperId": "1ff82acd7854dfca7f241d5429b5885b1d99db95",
+          "title": "GraphRAFT: Retrieval Augmented Fine-Tuning for Knowledge Graphs on Graph Databases"
+        },
+        {
+          "paperId": "e2eb27ab435a3507c2926e39b4e47e763fc6e47f",
+          "title": "SRAG: Structured Retrieval-Augmented Generation for Multi-Entity Question Answering over Wikipedia Graph"
+        },
+        {
+          "paperId": "4da7b8c595ca33fec6c043b35e918a0999badbd4",
+          "title": "Knowledge Graph Path-Enhanced RAG for Intelligent Residency Q&A"
+        },
+        {
+          "paperId": "1a454582d3b3aaa6c6cd5b2be075958d13423f78",
+          "title": "RAG vs. GraphRAG: A Systematic Evaluation and Key Insights"
+        },
+        {
+          "paperId": "1ad5c67eac145253c80d68c5a9bef05895bd55a7",
+          "title": "Natural Language Processing Techniques for Information Retrieval Enhancing Search Engines with Semantic Understanding"
+        },
+        {
+          "paperId": "1be5d5de1f311f7c3d930358d46b2b65f9e3ebc3",
+          "title": "Extraction-Augmented Generation of Scientific Abstracts Using Knowledge Graphs"
+        },
+        {
+          "paperId": "4996c27ee9436405c4b19012b4dfe12caf4d26e0",
+          "title": "Optimizing open-domain question answering with graph-based retrieval augmented generation"
+        },
+        {
+          "paperId": "7cb31f9eed220394ef8a6173bfc1a3ec069451be",
+          "title": "Enhancing Large Language Models (LLMs) for Telecommunications using Knowledge Graphs and Retrieval-Augmented Generation"
+        },
+        {
+          "paperId": "35f2900f88bd309b9660a43c99b4c25c2e68a8f5",
+          "title": "RAS: Retrieval-And-Structuring for Knowledge-Intensive LLM Generation"
+        },
+        {
+          "paperId": "e6b1402caedd2bc75441fd88451136ef1293ab4b",
+          "title": "RAG-Based Query Engine using LLM and Vector DB for College Details"
+        },
+        {
+          "paperId": "736acbdefb047adef26ad27a71a0ae4ad45b8a08",
+          "title": "KET-RAG: A Cost-Efficient Multi-Granular Indexing Framework for Graph-RAG"
+        },
+        {
+          "paperId": "93c978c0316ce434be6eea58f7ce037310ddf08b",
+          "title": "Is Relevance Propagated from Retriever to Generator in RAG?"
+        },
+        {
+          "paperId": "56224d31317101dbb154cf07d151803190eab249",
+          "title": "Generative Retrieval and Alignment Model: A New Paradigm for E-commerce Retrieval"
+        },
+        {
+          "paperId": "df3c487ba06d90f1510c2af5c781d35b76933d6f",
+          "title": "D4R -- Exploring and Querying Relational Graphs Using Natural Language and Large Language Models -- the Case of Historical Documents"
+        },
+        {
+          "paperId": "62bce220b471c7f524095e67dc300a1c4babcd48",
+          "title": "Mixture of Structural-and-Textual Retrieval over Text-rich Graph Knowledge Bases"
+        },
+        {
+          "paperId": "2298d7d3a24bffce28b69fef015c42132315e214",
+          "title": "question-answering system: integration of knowledge bases and language models to improve the efficiency of information processing"
+        }
+      ]
+    },
+    {
+      "paperId": "859cbed6555319c3c31b84c1001a1df9a34889e2",
+      "title": "Evaluating Token-Level and Passage-Level Dense Retrieval Models for Math Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "53615f5e4d2587519be7ed0f2136d3150f2465e2",
+          "title": "Dense Passage Retrieval in Conversational Search"
+        },
+        {
+          "paperId": "8c321c3a2cb7737d23014879096bd709b01e44c5",
+          "title": "Optimizing Retrieval Strategies for Financial Question Answering Documents in Retrieval-Augmented Generation Systems"
+        },
+        {
+          "paperId": "5af10e53941c4256cdd8d27b04eb1ca8f1f76218",
+          "title": "From Retrieval to Generation: Comparing Different Approaches"
+        },
+        {
+          "paperId": "c361530f27b11268ae338d04ab00e6114522aee0",
+          "title": "Reverse-Engineering the Retrieval Process in GenIR Models"
+        },
+        {
+          "paperId": "d1db1c018d37390ccfbd196703ad90c1fcdfb76f",
+          "title": "Pseudo-Relevance Feedback Can Improve Zero-Shot LLM-Based Dense Retrieval"
+        },
+        {
+          "paperId": "065ab6acd92293a0fb6124976a013cb1f2d1e060",
+          "title": "Teaching Dense Retrieval Models to Specialize with Listwise Distillation and LLM Data Augmentation"
+        },
+        {
+          "paperId": "45bed68f2ee2b86b1f739dda2e4ac6127190076a",
+          "title": "Unleashing the Power of LLMs in Dense Retrieval with Query Likelihood Modeling"
+        },
+        {
+          "paperId": "01d4be539755b248e4cb12f9b39085975f33fafa",
+          "title": "Hierarchical corpus encoder: Fusing generative retrieval and dense indices"
+        },
+        {
+          "paperId": "34847de1972491802d9f7c9347283a6b0973d755",
+          "title": "Advancing Vietnamese Information Retrieval with Learning Objective and Benchmark"
+        },
+        {
+          "paperId": "76fc1b0a9f5ce2044f314372af8c23839519a77e",
+          "title": "Granite Embedding Models"
+        },
+        {
+          "paperId": "15298b2abb4ce1b5bf57aa9e61f202d3b2ce577c",
+          "title": "DeepRetrieval: Powerful Query Generation for Information Retrieval with Reinforcement Learning"
+        },
+        {
+          "paperId": "58013e537854411630334b2837232e6db96bd9ab",
+          "title": "Enhancing Frame Detection with Retrieval Augmented Generation"
+        },
+        {
+          "paperId": "f40a03ac7d216205a70d28cfcea14cd69b9d46fb",
+          "title": "Retrieval-Augmented Visual Question Answering via Built-in Autoregressive Search Engines"
+        },
+        {
+          "paperId": "d00b9b7a22fa0f90a80bcdbd16f03d6a5f6017ba",
+          "title": "Retrieval-Augmented Generation with Hierarchical Knowledge"
+        },
+        {
+          "paperId": "a1220c406b6eb4b3fc1d7aa43e83a027153b5528",
+          "title": "MomentSeeker: A Comprehensive Benchmark and A Strong Baseline For Moment Retrieval Within Long Videos"
+        },
+        {
+          "paperId": "d5fbdd5f53afff00b57033b3d5ecc0a40844d120",
+          "title": "ReTreever: Tree-based Coarse-to-Fine Representations for Retrieval"
+        },
+        {
+          "paperId": "1dd582a26c435bc15671cfe11d0291b430d7d9f7",
+          "title": "Scaling Sparse and Dense Retrieval in Decoder-Only LLMs"
+        },
+        {
+          "paperId": "816fdd5c57e9391a450247a55978895640b62b20",
+          "title": "TempRetriever: Fusion-based Temporal Dense Passage Retrieval for Time-Sensitive Questions"
+        },
+        {
+          "paperId": "d500f728daff3a345d945887f436a25c2a78eb91",
+          "title": "ArchRAG: Attributed Community-based Hierarchical Retrieval-Augmented Generation"
+        },
+        {
+          "paperId": "9253360dd1087210815f8336a3edf44a06f5762d",
+          "title": "TREC 2023: h2oloo in the Product Search Challenge"
+        }
+      ]
+    },
+    {
+      "paperId": "9fdf2f248f509361a5eae8fea2a3e2fc8692b2b1",
+      "title": "On Single Server Private Information Retrieval With Private Coded Side Information",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "0173b93515e9956fc5942d3efeb00da8c5edb506",
+          "title": "On k-Mer-Based and Maximum Likelihood Estimation Algorithms for Trace Reconstruction"
+        },
+        {
+          "paperId": "1ef14f27b6f21cbe99f03317e14482b21a909fd7",
+          "title": "Non-Linear Function Computation Broadcast"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "8f60fdf042e69b1e755b7411087cddd310e6ba8b",
+          "title": "A Generalized Binary Tree Mechanism for Differentially Private Approximation of All-Pair Distances"
+        },
+        {
+          "paperId": "2647656c3ad8429d5a418787d273ce6a49d6c320",
+          "title": "One-Stage $ O(N \\log N)$ Algorithm for Generating Nested Rank-Minimized Representation of Electrically Large Volume Integral Equations"
+        },
+        {
+          "paperId": "c20b9c52982cfc2f8718181e50c3d8a971d7c959",
+          "title": "Logarithmic-Time Internal Pattern Matching Queries in Compressed and Dynamic Texts"
+        },
+        {
+          "paperId": "075da9a0f00a0b1ac9928afe440f397551eec680",
+          "title": "PtrHash: Minimal Perfect Hashing at RAM Throughput"
+        },
+        {
+          "paperId": "8d17b38e0663c2e90d3b953d2699a16c9ee2cbfc",
+          "title": "Bandwidth-Efficient Two-Server ORAMs with O(1) Client Storage"
+        },
+        {
+          "paperId": "e9da3d7ca49536e8943bc44bf683888db2be1b9e",
+          "title": "Systematic Parameter Decision in Approximate Model Counting"
+        },
+        {
+          "paperId": "29a70402fb12d0809e061f9160d2eca44adba14f",
+          "title": "Spend Your Budget Wisely: Towards an Intelligent Distribution of the Privacy Budget in Differentially Private Text Rewriting"
+        },
+        {
+          "paperId": "b995b5bbdfbae4409141c21b2a34908ddf796b75",
+          "title": "Factorised Representations of Join Queries: Tight Bounds and a New Dichotomy"
+        },
+        {
+          "paperId": "5b983328b5632d975c5deb6e5048c7e378c54c92",
+          "title": "A note on the Walsh spectrum of the Flystel"
+        },
+        {
+          "paperId": "e8b6e8924bad2943cb7e603d745ed985b38bb053",
+          "title": "Parameterized Algorithms for Matching Integer Programs with Additional Rows and Columns"
+        },
+        {
+          "paperId": "3d5da2623339377216b0a992cf648c4d77c223dc",
+          "title": "Semi-Streaming Algorithms for Hypergraph Matching"
+        }
+      ]
+    },
+    {
+      "paperId": "16b14352b57316faa65ff7837ef99f0e14a021bd",
+      "title": "Improved Weakly Private Information Retrieval Codes",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "74df03508f699be171137be5146045b83dbe6967",
+          "title": "Two Is All It Takes: Asymptotic and Concrete Improvements for Solving Code Equivalence"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "f09e8323446d7497742af869588e5afb882a8f9b",
+          "title": "Scalable Private Partition Selection via Adaptive Weighting"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "de641d51e2129aca70f53193f547d26437a32262",
+          "title": "Trapdoor Hash Functions and PIR from Low-Noise LPN"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "6fde6a2207382ebd6eec47219ae0017b9d2520ca",
+          "title": "Mildly Accurate Computationally Differentially Private Inner Product Protocols Imply Oblivious Transfer"
+        },
+        {
+          "paperId": "ccaa27d7970539608515a54b9f7693d149120898",
+          "title": "PREAMBLE: Private and Efficient Aggregation of Block Sparse Vectors and Applications"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "a19ec57277b1265085aa0dcaeee17b2ef7ea9969",
+          "title": "Sublinear-Overhead Secure Linear Algebra on a Dishonest Server"
+        },
+        {
+          "paperId": "e07bbecce58ba828f548628e9a26985bbfdba592",
+          "title": "Bit-Fixing Extractors for Almost-Logarithmic Entropy"
+        },
+        {
+          "paperId": "568e834b0684282b3da6656c01685407558a6c93",
+          "title": "Error Correction for Message Streams"
+        }
+      ]
+    },
+    {
+      "paperId": "6082dac939e66e1bcacff730bae9d27672f9f020",
+      "title": "The Capacity of T-Private Information Retrieval With Private Side Information",
+      "recommendations": [
+        {
+          "paperId": "0173b93515e9956fc5942d3efeb00da8c5edb506",
+          "title": "On k-Mer-Based and Maximum Likelihood Estimation Algorithms for Trace Reconstruction"
+        },
+        {
+          "paperId": "f39cccafa786b9aa606243bef89b7857ca938d79",
+          "title": "Model and Program Repair via Group Actions and Structure Unwinding"
+        },
+        {
+          "paperId": "2647656c3ad8429d5a418787d273ce6a49d6c320",
+          "title": "One-Stage $ O(N \\log N)$ Algorithm for Generating Nested Rank-Minimized Representation of Electrically Large Volume Integral Equations"
+        },
+        {
+          "paperId": "753792083bcc6be46df959008301033c23469cc0",
+          "title": "The structure of the $$v_2$$-local algebraic $$\\text {tmf}$$ resolution"
+        },
+        {
+          "paperId": "d057c8d7f4484b448cc191a25fcbd60dab04493b",
+          "title": "COVERING INTEGERS BY \n$x^2 + dy^2$"
+        },
+        {
+          "paperId": "2694d144b9ca51fed1def9b4f3f18f3f4471401b",
+          "title": "Structure and substructure connectivity of folded divide-and-swap cube"
+        },
+        {
+          "paperId": "5b983328b5632d975c5deb6e5048c7e378c54c92",
+          "title": "A note on the Walsh spectrum of the Flystel"
+        },
+        {
+          "paperId": "fd0f04db743a887ea118a768d4219cb5951b58aa",
+          "title": "Type systems and maximal subgroups of Thompson’s group 𝑉"
+        },
+        {
+          "paperId": "54b9bd82fab2be478aadc798682dc1ee4a7199d2",
+          "title": "Joint Extremes of Inversions and Descents of Random Permutations"
+        },
+        {
+          "paperId": "a993ca4416f85aaddaa9f125085606a1e0828e40",
+          "title": "On the bijectivity of the map $$\\chi $$"
+        },
+        {
+          "paperId": "4c0489d5ea06fff80c18083ab1ae4d256952ef59",
+          "title": "Characterization of the tree cycles with minimum positive entropy for any period"
+        },
+        {
+          "paperId": "dd8378a7e3053762e099ca83785cfc3aae7a3377",
+          "title": "Performance Evaluation of Cross M-QAM Modulation Over Standardized RF2 5G Frequency Bands Using the η-μ Fading Model"
+        },
+        {
+          "paperId": "ec26728295cfec4b2eecefd3129995ed9e46aada",
+          "title": "Power Transformed Density Ridge Estimation"
+        },
+        {
+          "paperId": "bf1ea89247f296f86edccbe6535393f19a5fd974",
+          "title": "A character theoretic formula for the base size"
+        },
+        {
+          "paperId": "a015e735d57a36dd4d6d570d7c546392f65a2956",
+          "title": "Bounds on the Pythagoras number and indecomposables in biquadratic fields"
+        },
+        {
+          "paperId": "948ae4574249951a976b3a921d4311683ad57f4d",
+          "title": "Transistors With MoS<inline-formula><tex-math notation=\"LaTeX\">$_{2}$</tex-math></inline-formula> Subnanometer Channels Embedded in 2D WSe<inline-formula><tex-math notation=\"LaTeX\">$_{2}$</tex-math></inline-formula>"
+        },
+        {
+          "paperId": "2572bebfd49ccccf482cd1c696011af95bf2a52a",
+          "title": "Level sets of prevalent Hölder functions"
+        },
+        {
+          "paperId": "5f6a82ef0f742ecab77bbcb08f3564d1a0c2cbe2",
+          "title": "Characterizations of the $$\\textbf{u}$$-prenucleolus by dually-$$\\textbf{u}$$-essential coalitions"
+        },
+        {
+          "paperId": "a9f9d5dc19653dc8ec52da063b79846d48b5e669",
+          "title": "A note on digraph splitting"
+        },
+        {
+          "paperId": "c688eb1b2692f07807e0a3cac93bd2ce1880b0cc",
+          "title": "Saturated Fusion Systems on 𝑝-Groups of Maximal Class"
+        }
+      ]
+    },
+    {
+      "paperId": "0f49917a1dfafac3d8353d084467ce04cd58aec2",
+      "title": "The Curse of Dense Low-Dimensional Information Retrieval for Large Index Sizes",
+      "recommendations": [
+        {
+          "paperId": "47735ee1c21a3ac9fcc9a9e159416d78d1352183",
+          "title": "Efficient Inverted Index-based Approximate Retrieval over High-dimensional Learned Sparse Representations"
+        },
+        {
+          "paperId": "a463695c1e8a03315c486ba620bd749cd9076f53",
+          "title": "Efficient Constant-Space Multi-Vector Retrieval"
+        },
+        {
+          "paperId": "036402466032a2bbd4f0fae07c29049f6142975a",
+          "title": "On the Reproducibility of Learned Sparse Retrieval Adaptations for Long Documents"
+        },
+        {
+          "paperId": "d5fbdd5f53afff00b57033b3d5ecc0a40844d120",
+          "title": "ReTreever: Tree-based Coarse-to-Fine Representations for Retrieval"
+        },
+        {
+          "paperId": "e82ba75223dacbc080c095835cad5a9103d9cae5",
+          "title": "LSTM-based Selective Dense Text Retrieval Guided by Sparse Lexical Retrieval"
+        },
+        {
+          "paperId": "46969656f0db9f4c49834f02dce42748cb1b6f0d",
+          "title": "Similarity Measures for Music Retrieval"
+        },
+        {
+          "paperId": "d1db1c018d37390ccfbd196703ad90c1fcdfb76f",
+          "title": "Pseudo-Relevance Feedback Can Improve Zero-Shot LLM-Based Dense Retrieval"
+        },
+        {
+          "paperId": "9744a4a086a39eda0f61ebe4302fc8105dc0b270",
+          "title": "Graph-Based Algorithms for Diverse Similarity Search"
+        },
+        {
+          "paperId": "8916c521f05722ce8bab5da74cae5bb51963c422",
+          "title": "LapSum -- One Method to Differentiate Them All: Ranking, Sorting and Top-k Selection"
+        },
+        {
+          "paperId": "4e7b74e1aed1494e01a3f68106e876eefbbdd0e4",
+          "title": "Scalable k-Means Clustering for Large k via Seeded Approximate Nearest-Neighbor Search"
+        },
+        {
+          "paperId": "6346e93897d3019fc1b2ee4649ed005b2b05b86d",
+          "title": "High-dimensional density-based clustering using locality-sensitive hashing"
+        },
+        {
+          "paperId": "c3725ad994632c7146ca27d9c6d08673967ae083",
+          "title": "The DiskANN library: Graph-Based Indices for Fast, Fresh and Filtered Vector Search"
+        },
+        {
+          "paperId": "774dfacb2817becdd0a32665981976a095ca5218",
+          "title": "VisIRR: An Interactive Visual System for Information Retrieval and Recommendation for Large-scale Document Data"
+        },
+        {
+          "paperId": "9408a4f1bbc71dad90e6b89e72440956aad0a07c",
+          "title": "Clustering-based Low Rank Approximation Method"
+        },
+        {
+          "paperId": "d03d116cb403845f9d6463c2927be92868833be3",
+          "title": "A Novel Approach for Intrinsic Dimension Estimation"
+        },
+        {
+          "paperId": "8c4bc5c552a7508789e68ea151c598b5b787ccb7",
+          "title": "LLM-VPRF: Large Language Model Based Vector Pseudo Relevance Feedback"
+        },
+        {
+          "paperId": "01d985bff198114e731e4bc820e25594a4b3e669",
+          "title": "Ordered Semantically Diverse Sampling for Textual Data"
+        },
+        {
+          "paperId": "cd23d95216ae5270d7164ce9f0087530c7bfd82f",
+          "title": "Unsupervised Feature Selection for High-Order Embedding Learning and Sparse Learning."
+        },
+        {
+          "paperId": "cff1874505e90574f9d34ae6c0972817a0161d54",
+          "title": "ESANS: Effective and Semantic-Aware Negative Sampling for Large-Scale Retrieval Systems"
+        },
+        {
+          "paperId": "de4dec693d400eb2713af95a9be9d085e0c97696",
+          "title": "Scalable Binary CUR Low-Rank Approximation Algorithm"
+        }
+      ]
+    },
+    {
+      "paperId": "335185b0105cac27de0688ea90653c4c540de976",
+      "title": "Cross-lingual Information Retrieval with BERT",
+      "recommendations": [
+        {
+          "paperId": "9b8e2834cfe92c88ce63db51277f1b95702989f2",
+          "title": "Extending Monolingual Asymmetric Semantic Search Models For Multilingual Query Processing Using Knowledge Distillation"
+        },
+        {
+          "paperId": "3b308b5f7ea3cdb7b42cfc07bed34fe55957c335",
+          "title": "Comparative Analysis of Improved Versions of BERT Models on Chinese NLP Tasks"
+        },
+        {
+          "paperId": "3c5a8eb1870b86f3b2683cef50e99ba7ecb46668",
+          "title": "LayAlign: Enhancing Multilingual Reasoning in Large Language Models via Layer-Wise Adaptive Fusion and Alignment Strategy"
+        },
+        {
+          "paperId": "34847de1972491802d9f7c9347283a6b0973d755",
+          "title": "Advancing Vietnamese Information Retrieval with Learning Objective and Benchmark"
+        },
+        {
+          "paperId": "8b26b896afd90fe1dc450bed8ca6093172550f40",
+          "title": "PolyPrompt: Automating Knowledge Extraction from Multilingual Language Models with Dynamic Prompt Generation"
+        },
+        {
+          "paperId": "41ac6ffaf037bde57bb95c252a36762e90f04dc6",
+          "title": "An Expanded Massive Multilingual Dataset for High-Performance Language Technologies"
+        },
+        {
+          "paperId": "6471fb636d64b78c2c206f5459dfbf244dccd17f",
+          "title": "Research on Vocabulary Optimization of Multilingual Models for Low-Resource Languages"
+        },
+        {
+          "paperId": "ca495889b87542e4fb04b5f45b514802411d2ecf",
+          "title": "MMTEB: Massive Multilingual Text Embedding Benchmark"
+        },
+        {
+          "paperId": "615c116e4796280b9343b956befafd639033ee79",
+          "title": "LANGALIGN: Enhancing Non-English Language Models via Cross-Lingual Embedding Alignment"
+        },
+        {
+          "paperId": "42b4c8cf2f4f28d47ff0ad1c7c5aa18e66852919",
+          "title": "On the Consistency of Multilingual Context Utilization in Retrieval-Augmented Generation"
+        },
+        {
+          "paperId": "4510809bba5bd259e2f12f0f2db347205bfb4cb6",
+          "title": "Word2winners at SemEval-2025 Task 7: Multilingual and Crosslingual Fact-Checked Claim Retrieval"
+        },
+        {
+          "paperId": "d91e11d208b55d656d649a4f909416a0d708bf1c",
+          "title": "Cross-Encoder Models in Czech"
+        },
+        {
+          "paperId": "01d4be539755b248e4cb12f9b39085975f33fafa",
+          "title": "Hierarchical corpus encoder: Fusing generative retrieval and dense indices"
+        },
+        {
+          "paperId": "b30e05485237396b8719986e353171ef13bd983c",
+          "title": "Enhancing Bilingual Lexicon Induction with Dynamic Translation"
+        },
+        {
+          "paperId": "57b243d858b1907934a43e8ee083a0205e3b3fdd",
+          "title": "Empirical Evaluation of Pre-trained Language Models for Summarizing Moroccan Darija News Articles"
+        },
+        {
+          "paperId": "55dc414507b71526d5697ef12e16c7b1a3bfca69",
+          "title": "Automatic recognition of cross-language classic entities based on large language models"
+        },
+        {
+          "paperId": "8e27b3a179f6a6e5592ac6ff093e762c3587fedd",
+          "title": "Investigating Language Preference of Multilingual RAG Systems"
+        },
+        {
+          "paperId": "ba8622c1b2f8d37489afefa02235cbef7cfca14b",
+          "title": "Cross-Encoder-Based Semantic Evaluation of Extractive and Generative Question Answering in Low-Resourced African Languages"
+        },
+        {
+          "paperId": "ca56ad82a42ac28fd42686371a67c2a6272d7102",
+          "title": "Examining Multilingual Embedding Models Cross-Lingually Through LLM-Generated Adversarial Examples"
+        },
+        {
+          "paperId": "76fc1b0a9f5ce2044f314372af8c23839519a77e",
+          "title": "Granite Embedding Models"
+        }
+      ]
+    },
+    {
+      "paperId": "7058531a7a629476a5482baab5560ffb97e9600f",
+      "title": "Symmetric Private Information Retrieval with User-Side Common Randomness",
+      "recommendations": [
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "d543d40262efdf23d1a24e7a8b63e5000ce59971",
+          "title": "Improving User Privacy in Practical Quantum Private Query with Group Honesty Checking"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "a47357735a96cefbf8416099137292a41a80b8ff",
+          "title": "Vector Linear Secure Aggregation"
+        },
+        {
+          "paperId": "41b1e102fae3575583e1f9b8fb63becc5577605d",
+          "title": "Differential Privacy"
+        },
+        {
+          "paperId": "c8cb0f9fd50ff326c3455f54aa81e34f155d61e2",
+          "title": "Uncoordinated Syntactic Privacy: A New Composable Metric for Multiple, Independent Data Publishing"
+        },
+        {
+          "paperId": "d8c56a44866c508db82e8e8616d322c5432b4ff6",
+          "title": "Recurrent Private Set Intersection for Unbalanced Databases with Cuckoo Hashing and Leveled FHE"
+        },
+        {
+          "paperId": "7a76b13c94f7f74ab50bab93537902155c7f7e68",
+          "title": "Probabilistic analysis of data structures for locality-sensitive hashing functions"
+        },
+        {
+          "paperId": "57102831121032b00f1e67608a1d9c797e9a0ad2",
+          "title": "Efficient and Expressive Public Key Authenticated Encryption with Keyword Search in Multi-user Scenarios"
+        },
+        {
+          "paperId": "e0687f8c142d336b8897509ed7083be264305031",
+          "title": "Rational Secret Sharing with Competition"
+        },
+        {
+          "paperId": "af8bd8092c18095f474c5f4dff0037863e71a302",
+          "title": "Privacy-Preserving Data Sharing and Computing for Outsourced Policy Iteration with Attempt Records from Multiple Users"
+        }
+      ]
+    },
+    {
+      "paperId": "9e7ebc43914bceb2f332511b39aedea9db231aef",
+      "title": "Two-Level Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "1ef14f27b6f21cbe99f03317e14482b21a909fd7",
+          "title": "Non-Linear Function Computation Broadcast"
+        },
+        {
+          "paperId": "8f60fdf042e69b1e755b7411087cddd310e6ba8b",
+          "title": "A Generalized Binary Tree Mechanism for Differentially Private Approximation of All-Pair Distances"
+        },
+        {
+          "paperId": "117c3330848bbc62e286500dad5562a704df2634",
+          "title": "On the query complexity of sampling from non-log-concave distributions"
+        },
+        {
+          "paperId": "88b9b3f1de71356c71a8d496bf8cb43381ae1d48",
+          "title": "Variance-Dependent Regret Lower Bounds for Contextual Bandits"
+        },
+        {
+          "paperId": "5e2040d843ab9a1eb22c0e64fc90fc3702cb8a73",
+          "title": "Translation-Invariant Quantum Algorithms for Ordered Search are Optimal"
+        },
+        {
+          "paperId": "29a70402fb12d0809e061f9160d2eca44adba14f",
+          "title": "Spend Your Budget Wisely: Towards an Intelligent Distribution of the Privacy Budget in Differentially Private Text Rewriting"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "2dac4fcb0a87f21c4ee0fb5d2ed6d8b730cf1932",
+          "title": "Geometric Bipartite Matching Based Exact Algorithms for Server Problems"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "075da9a0f00a0b1ac9928afe440f397551eec680",
+          "title": "PtrHash: Minimal Perfect Hashing at RAM Throughput"
+        },
+        {
+          "paperId": "6313de4470a0f72c3b4bcd6a293dcf53baca2142",
+          "title": "New Rates in Stochastic Decision-Theoretic Online Learning under Differential Privacy"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "c20b9c52982cfc2f8718181e50c3d8a971d7c959",
+          "title": "Logarithmic-Time Internal Pattern Matching Queries in Compressed and Dynamic Texts"
+        },
+        {
+          "paperId": "8d17b38e0663c2e90d3b953d2699a16c9ee2cbfc",
+          "title": "Bandwidth-Efficient Two-Server ORAMs with O(1) Client Storage"
+        },
+        {
+          "paperId": "d51876dd9c9c2b8d959b0e9a1b55074ec30dd88e",
+          "title": "Decomposing a factorial into large factors"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        }
+      ]
+    },
+    {
+      "paperId": "ee85d975f578729e840dc3638adb753fb2d87f52",
+      "title": "Verifiable single-server private information retrieval from LWE with binary errors",
+      "recommendations": [
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "6fd850392b509e63582a925cb8ab822568a557af",
+          "title": "Multi-party probabilistic quantum homomorphic encryption scheme based on Brown state"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "4b376cc77efddb220d3306254948367c402f6095",
+          "title": "Cryptanalysis on Lightweight Verifiable Homomorphic Encryption"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "0ed85334e7b15f7565b563c6870618b41d585612",
+          "title": "Signatures with Tight Adaptive Corruptions from Search Assumptions"
+        },
+        {
+          "paperId": "cceb1a4e3f57a194ed0208fc808a5dc228abc9a3",
+          "title": "Towards Optimally Secure Deterministic Authenticated Encryption Schemes"
+        },
+        {
+          "paperId": "4b6f18f67dc97c73d9f3a76a2ddd4747bdb931b1",
+          "title": "Lightweight Single-Server PIR with Oλ(n1/3) Communication"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "57102831121032b00f1e67608a1d9c797e9a0ad2",
+          "title": "Efficient and Expressive Public Key Authenticated Encryption with Keyword Search in Multi-user Scenarios"
+        },
+        {
+          "paperId": "de641d51e2129aca70f53193f547d26437a32262",
+          "title": "Trapdoor Hash Functions and PIR from Low-Noise LPN"
+        },
+        {
+          "paperId": "13e53aab4749f716deb834b2169e4c44152b0dcc",
+          "title": "Unidirectional quantum private comparison based on quantum private query"
+        },
+        {
+          "paperId": "afdbb5081e28a45406bd3e990c9b95399369d519",
+          "title": "Verifiable Computation for Approximate Homomorphic Encryption Schemes"
+        },
+        {
+          "paperId": "dc731be8a3c92bebf036a82748e17e45f23d2430",
+          "title": "Lightweight Multi-User Public-Key Authenticated Encryption With Keyword Search"
+        },
+        {
+          "paperId": "4e2471a80e0820157b46078aa9d092504e421a98",
+          "title": "Adaptively Secure Fully Homomorphic Message Authentication Code with Pre-processable Verification"
+        },
+        {
+          "paperId": "6b86fa4406528333bc60a73c13878feabb3429d4",
+          "title": "Authenticated BitGC for Actively Secure Rate-One 2PC"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "aa6d2b431f65a5ce9b81653cb4d8e23a02f809c1",
+          "title": "Theory and Applications of Sequentially Threshold Public-Key Cryptography: Practical Private Key Safeguarding and Secure Use for Individual Users"
+        },
+        {
+          "paperId": "a8fbfacbca2cd356274b95f48c567e5ab51c19c1",
+          "title": "Practical Circuit Privacy/Sanitization for TFHE"
+        },
+        {
+          "paperId": "fc6712081130c0126e1bc310a7bd244eb32d68f0",
+          "title": "Functional Oblivious Transfer with Applications in Privacy-Preserving Machine Learning"
+        }
+      ]
+    },
+    {
+      "paperId": "a104e0f6781ec1dd8bdc2ce054d118399d81bab6",
+      "title": "Semantic Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "0173b93515e9956fc5942d3efeb00da8c5edb506",
+          "title": "On k-Mer-Based and Maximum Likelihood Estimation Algorithms for Trace Reconstruction"
+        },
+        {
+          "paperId": "6bc3d0d2444d2482e551978e78ada90ad5a9d085",
+          "title": "Binary Classification From $M$-Tuple Similarity-Confidence Data"
+        },
+        {
+          "paperId": "fd0f04db743a887ea118a768d4219cb5951b58aa",
+          "title": "Type systems and maximal subgroups of Thompson’s group 𝑉"
+        },
+        {
+          "paperId": "5b983328b5632d975c5deb6e5048c7e378c54c92",
+          "title": "A note on the Walsh spectrum of the Flystel"
+        },
+        {
+          "paperId": "54b9bd82fab2be478aadc798682dc1ee4a7199d2",
+          "title": "Joint Extremes of Inversions and Descents of Random Permutations"
+        },
+        {
+          "paperId": "2694d144b9ca51fed1def9b4f3f18f3f4471401b",
+          "title": "Structure and substructure connectivity of folded divide-and-swap cube"
+        },
+        {
+          "paperId": "753792083bcc6be46df959008301033c23469cc0",
+          "title": "The structure of the $$v_2$$-local algebraic $$\\text {tmf}$$ resolution"
+        },
+        {
+          "paperId": "325f16326f4cf074b76ec8fffff8d4969160ebf3",
+          "title": "CMVC+: A Multi-View Clustering Framework for Open Knowledge Base Canonicalization Via Contrastive Learning"
+        },
+        {
+          "paperId": "4c0489d5ea06fff80c18083ab1ae4d256952ef59",
+          "title": "Characterization of the tree cycles with minimum positive entropy for any period"
+        },
+        {
+          "paperId": "d057c8d7f4484b448cc191a25fcbd60dab04493b",
+          "title": "COVERING INTEGERS BY \n$x^2 + dy^2$"
+        },
+        {
+          "paperId": "2647656c3ad8429d5a418787d273ce6a49d6c320",
+          "title": "One-Stage $ O(N \\log N)$ Algorithm for Generating Nested Rank-Minimized Representation of Electrically Large Volume Integral Equations"
+        },
+        {
+          "paperId": "bf1ea89247f296f86edccbe6535393f19a5fd974",
+          "title": "A character theoretic formula for the base size"
+        },
+        {
+          "paperId": "a993ca4416f85aaddaa9f125085606a1e0828e40",
+          "title": "On the bijectivity of the map $$\\chi $$"
+        },
+        {
+          "paperId": "a015e735d57a36dd4d6d570d7c546392f65a2956",
+          "title": "Bounds on the Pythagoras number and indecomposables in biquadratic fields"
+        },
+        {
+          "paperId": "c688eb1b2692f07807e0a3cac93bd2ce1880b0cc",
+          "title": "Saturated Fusion Systems on 𝑝-Groups of Maximal Class"
+        },
+        {
+          "paperId": "7edf14e05a761e54f042d33c372c7179167f3c3f",
+          "title": "Towards a~better understanding of 𝒞𝑝 functions and definable 𝒞𝑝 functions of several variables"
+        },
+        {
+          "paperId": "f39cccafa786b9aa606243bef89b7857ca938d79",
+          "title": "Model and Program Repair via Group Actions and Structure Unwinding"
+        },
+        {
+          "paperId": "2572bebfd49ccccf482cd1c696011af95bf2a52a",
+          "title": "Level sets of prevalent Hölder functions"
+        },
+        {
+          "paperId": "a9f9d5dc19653dc8ec52da063b79846d48b5e669",
+          "title": "A note on digraph splitting"
+        },
+        {
+          "paperId": "2d6f0f38e7b568f94f45767481bf21fbb175f197",
+          "title": "Property Testing of Curve Similarity"
+        }
+      ]
+    },
+    {
+      "paperId": "81da144a8496cea00ab5859e939090750a16c271",
+      "title": "Capacity of Quantum Private Information Retrieval with Colluding Servers",
+      "recommendations": [
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "9a37eb5f38b50b5733af935ca505e316a8ca8739",
+          "title": "Efficient (k, n) threshold semi-quantum secret sharing protocol"
+        },
+        {
+          "paperId": "6fd850392b509e63582a925cb8ab822568a557af",
+          "title": "Multi-party probabilistic quantum homomorphic encryption scheme based on Brown state"
+        },
+        {
+          "paperId": "ab9e81f2bd126b9c147907b869e6ec8d4668919e",
+          "title": "Does there exist a quantum fingerprinting protocol without coherent measurements?"
+        },
+        {
+          "paperId": "0ca8ff2a8567e655a99cad07c90e4e6e7623509b",
+          "title": "Universal quantum homomorphic encryption based on $(k, n)$-threshold quantum state sharing"
+        },
+        {
+          "paperId": "d543d40262efdf23d1a24e7a8b63e5000ce59971",
+          "title": "Improving User Privacy in Practical Quantum Private Query with Group Honesty Checking"
+        },
+        {
+          "paperId": "e8ecbe483d05ad0d641b6f581b71db39428f9aef",
+          "title": "Multiparty Quantum Private Comparison Using Rotation Operations"
+        },
+        {
+          "paperId": "13e53aab4749f716deb834b2169e4c44152b0dcc",
+          "title": "Unidirectional quantum private comparison based on quantum private query"
+        },
+        {
+          "paperId": "9d6d119be7d9186e7cc5d68cc91ff2da41d0c7f0",
+          "title": "Non-Interactive and Non-Destructive Zero-Knowledge Proofs on Quantum States and Multi-Party Generation of Authorized Hidden GHZ States"
+        },
+        {
+          "paperId": "52baa11ec019e7bbdc1f5102b80dd9071050da27",
+          "title": "Implementation of classical client universal blind quantum computation with 8-state RSP in current architecture"
+        },
+        {
+          "paperId": "a9840ca785043a6837ae629f6b16bc77ca4ba979",
+          "title": "Efficient hyperentanglement-based quantum secret sharing protocol"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "266af7c176babe6fc941ffe589bc5f3e42152f57",
+          "title": "Security Analysis of Biased Basis for Efficient BB84"
+        },
+        {
+          "paperId": "6a6d527bddb1c8a345c7c7045ddb69cb8c4546fc",
+          "title": "Quantum Privacy Comparison with Ry Rotation Operation"
+        },
+        {
+          "paperId": "1d987bc78ce356a77f540061eca463b1703ea0ea",
+          "title": "secret sharing with quantum graph states"
+        },
+        {
+          "paperId": "3fe0c899bb0037a6ca6d315044663d296e6f9208",
+          "title": "Strengthening the No-Go Theorem for QRNGs"
+        },
+        {
+          "paperId": "ea53dfe7149dfd1ad577db95a242d05971c16c6b",
+          "title": "Authenticated Sublinear Quantum Private Information Retrieval"
+        },
+        {
+          "paperId": "56ef54faeac9e47583903f26f9282b7afca4ca36",
+          "title": "Toward the Impossibility of Perfect Complete Quantum PKE from OWFs"
+        },
+        {
+          "paperId": "bfb22477a30fd684d42882200b9b8162d0fb9973",
+          "title": "Complement Sampling: Provable, Verifiable and NISQable Quantum Advantage in Sample Complexity"
+        }
+      ]
+    },
+    {
+      "paperId": "6e5586555c31cb68370ade59e50cc30645b4a386",
+      "title": "Asymmetric Leaky Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "29a70402fb12d0809e061f9160d2eca44adba14f",
+          "title": "Spend Your Budget Wisely: Towards an Intelligent Distribution of the Privacy Budget in Differentially Private Text Rewriting"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "c8cb0f9fd50ff326c3455f54aa81e34f155d61e2",
+          "title": "Uncoordinated Syntactic Privacy: A New Composable Metric for Multiple, Independent Data Publishing"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "8f60fdf042e69b1e755b7411087cddd310e6ba8b",
+          "title": "A Generalized Binary Tree Mechanism for Differentially Private Approximation of All-Pair Distances"
+        },
+        {
+          "paperId": "874b6e2b2933c7d563c16b9597bb579bf1ed3263",
+          "title": "Information Theory Strikes Back: New Development in the Theory of Cardinality Estimation"
+        },
+        {
+          "paperId": "de641d51e2129aca70f53193f547d26437a32262",
+          "title": "Trapdoor Hash Functions and PIR from Low-Noise LPN"
+        },
+        {
+          "paperId": "6fde6a2207382ebd6eec47219ae0017b9d2520ca",
+          "title": "Mildly Accurate Computationally Differentially Private Inner Product Protocols Imply Oblivious Transfer"
+        },
+        {
+          "paperId": "41b1e102fae3575583e1f9b8fb63becc5577605d",
+          "title": "Differential Privacy"
+        },
+        {
+          "paperId": "2d6f0f38e7b568f94f45767481bf21fbb175f197",
+          "title": "Property Testing of Curve Similarity"
+        },
+        {
+          "paperId": "d543d40262efdf23d1a24e7a8b63e5000ce59971",
+          "title": "Improving User Privacy in Practical Quantum Private Query with Group Honesty Checking"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "8e8e785856d7af05ad5db7e46a0a84b2c091ac11",
+          "title": "Femur: A Flexible Framework for Fast and Secure Querying from Public Key-Value Store"
+        },
+        {
+          "paperId": "89b2d8c8c798d7c9c4f2fb61d985f54589464648",
+          "title": "Smoothed Normalization for Efficient Distributed Private Optimization"
+        }
+      ]
+    },
+    {
+      "paperId": "3e34f0937ab064d53579013d4d986e10780c32af",
+      "title": "Multi-Server Weakly-Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "09b73fe067ef51d335bc182675a352c997f09491",
+          "title": "Veriﬁable Secret Sharing Based on Fully Batchable Polynomial Commitment for Privacy-Preserving Distributed Computation"
+        },
+        {
+          "paperId": "e9ffc414265b7509d873bdc81d028e3e9960b40b",
+          "title": "Non-interactive Anonymous Tokens with Private Metadata Bit"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "d543d40262efdf23d1a24e7a8b63e5000ce59971",
+          "title": "Improving User Privacy in Practical Quantum Private Query with Group Honesty Checking"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "64dffdec8bc838d1a25871802c2f67d4155a8b21",
+          "title": "Beyond Access Pattern: Efficient Volume-Hiding Multi-Range Queries Over Outsourced Data Services"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "8d17b38e0663c2e90d3b953d2699a16c9ee2cbfc",
+          "title": "Bandwidth-Efficient Two-Server ORAMs with O(1) Client Storage"
+        },
+        {
+          "paperId": "c8cb0f9fd50ff326c3455f54aa81e34f155d61e2",
+          "title": "Uncoordinated Syntactic Privacy: A New Composable Metric for Multiple, Independent Data Publishing"
+        },
+        {
+          "paperId": "65dc1c5a3b483fc39e5017ab616622dadebd6fce",
+          "title": "Efficient Private Set Intersection Protocols with Semi-trusted Cloud Server Aided"
+        },
+        {
+          "paperId": "aa6d2b431f65a5ce9b81653cb4d8e23a02f809c1",
+          "title": "Theory and Applications of Sequentially Threshold Public-Key Cryptography: Practical Private Key Safeguarding and Secure Use for Individual Users"
+        }
+      ]
+    },
+    {
+      "paperId": "535be2f780076085ca1b59cbfed43e3dc3339f23",
+      "title": "Double Blind T-Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "0173b93515e9956fc5942d3efeb00da8c5edb506",
+          "title": "On k-Mer-Based and Maximum Likelihood Estimation Algorithms for Trace Reconstruction"
+        },
+        {
+          "paperId": "ec26728295cfec4b2eecefd3129995ed9e46aada",
+          "title": "Power Transformed Density Ridge Estimation"
+        },
+        {
+          "paperId": "f39cccafa786b9aa606243bef89b7857ca938d79",
+          "title": "Model and Program Repair via Group Actions and Structure Unwinding"
+        },
+        {
+          "paperId": "5b983328b5632d975c5deb6e5048c7e378c54c92",
+          "title": "A note on the Walsh spectrum of the Flystel"
+        },
+        {
+          "paperId": "2694d144b9ca51fed1def9b4f3f18f3f4471401b",
+          "title": "Structure and substructure connectivity of folded divide-and-swap cube"
+        },
+        {
+          "paperId": "2647656c3ad8429d5a418787d273ce6a49d6c320",
+          "title": "One-Stage $ O(N \\log N)$ Algorithm for Generating Nested Rank-Minimized Representation of Electrically Large Volume Integral Equations"
+        },
+        {
+          "paperId": "753792083bcc6be46df959008301033c23469cc0",
+          "title": "The structure of the $$v_2$$-local algebraic $$\\text {tmf}$$ resolution"
+        },
+        {
+          "paperId": "a993ca4416f85aaddaa9f125085606a1e0828e40",
+          "title": "On the bijectivity of the map $$\\chi $$"
+        },
+        {
+          "paperId": "d057c8d7f4484b448cc191a25fcbd60dab04493b",
+          "title": "COVERING INTEGERS BY \n$x^2 + dy^2$"
+        },
+        {
+          "paperId": "54b9bd82fab2be478aadc798682dc1ee4a7199d2",
+          "title": "Joint Extremes of Inversions and Descents of Random Permutations"
+        },
+        {
+          "paperId": "5f6a82ef0f742ecab77bbcb08f3564d1a0c2cbe2",
+          "title": "Characterizations of the $$\\textbf{u}$$-prenucleolus by dually-$$\\textbf{u}$$-essential coalitions"
+        },
+        {
+          "paperId": "109121d0d814ba3ec4a7eb0e9ba199cc8a92c597",
+          "title": "Tensor K-Matrices for Quantum Symmetric Pairs"
+        },
+        {
+          "paperId": "7bd54bbbbe2249c143e466ab2b3597a2d3a55842",
+          "title": "On the \n$\\mu$\n-invariant of two-variable \n$2$\n-adic \n$\\boldsymbol{L}$\n-functions"
+        },
+        {
+          "paperId": "a015e735d57a36dd4d6d570d7c546392f65a2956",
+          "title": "Bounds on the Pythagoras number and indecomposables in biquadratic fields"
+        },
+        {
+          "paperId": "7e13653756cfd3d3869336737e9c36bf99bd3c20",
+          "title": "An example of a weakly mixing $${{\\,\\textrm{BV}\\,}}$$ vector field which is not strongly mixing"
+        },
+        {
+          "paperId": "bf1ea89247f296f86edccbe6535393f19a5fd974",
+          "title": "A character theoretic formula for the base size"
+        },
+        {
+          "paperId": "948ae4574249951a976b3a921d4311683ad57f4d",
+          "title": "Transistors With MoS<inline-formula><tex-math notation=\"LaTeX\">$_{2}$</tex-math></inline-formula> Subnanometer Channels Embedded in 2D WSe<inline-formula><tex-math notation=\"LaTeX\">$_{2}$</tex-math></inline-formula>"
+        },
+        {
+          "paperId": "dd8378a7e3053762e099ca83785cfc3aae7a3377",
+          "title": "Performance Evaluation of Cross M-QAM Modulation Over Standardized RF2 5G Frequency Bands Using the η-μ Fading Model"
+        },
+        {
+          "paperId": "4c0489d5ea06fff80c18083ab1ae4d256952ef59",
+          "title": "Characterization of the tree cycles with minimum positive entropy for any period"
+        },
+        {
+          "paperId": "ab5fa816bd3a288252bd2050d281aa023b87411a",
+          "title": "Hikita-nakajima conjecture for the Gieseker variety"
+        }
+      ]
+    },
+    {
+      "paperId": "061f91b67542e72de4f37a523998c6456eeabd6d",
+      "title": "The Capacity of Symmetric Private Information Retrieval Under Arbitrary Collusion and Eavesdropping Patterns",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "117c3330848bbc62e286500dad5562a704df2634",
+          "title": "On the query complexity of sampling from non-log-concave distributions"
+        },
+        {
+          "paperId": "8f60fdf042e69b1e755b7411087cddd310e6ba8b",
+          "title": "A Generalized Binary Tree Mechanism for Differentially Private Approximation of All-Pair Distances"
+        },
+        {
+          "paperId": "d4cdb59ed03e43a19001bb2913348674b51d285b",
+          "title": "Information-Theoretic Security Problem in Cluster Distributed Storage Systems: Regenerating Code Against Two General Types of Eavesdroppers"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "8a45a9451e30076fca1699634c0dad6effbc7b96",
+          "title": "Distributed Non-Interactive Zero-Knowledge Proofs"
+        },
+        {
+          "paperId": "2d6f0f38e7b568f94f45767481bf21fbb175f197",
+          "title": "Property Testing of Curve Similarity"
+        },
+        {
+          "paperId": "b995b5bbdfbae4409141c21b2a34908ddf796b75",
+          "title": "Factorised Representations of Join Queries: Tight Bounds and a New Dichotomy"
+        },
+        {
+          "paperId": "e8b6e8924bad2943cb7e603d745ed985b38bb053",
+          "title": "Parameterized Algorithms for Matching Integer Programs with Additional Rows and Columns"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "afdbb5081e28a45406bd3e990c9b95399369d519",
+          "title": "Verifiable Computation for Approximate Homomorphic Encryption Schemes"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "e7439dffa2dc2178cdaf57d7dd4423ac628740bb",
+          "title": "Approximation guarantees of Median Mechanism in ℝd"
+        },
+        {
+          "paperId": "fddcec45ca788b1c4e23812ea6c5423eb9c6ebe3",
+          "title": "Infinitely Divisible Noise for Differential Privacy: Nearly Optimal Error in the High $\\varepsilon$ Regime"
+        },
+        {
+          "paperId": "d8e0b1cd39fd91608515cbc1aa1739fabba3f19e",
+          "title": "A Tolerant Independent Set Tester"
+        },
+        {
+          "paperId": "e66c085465b3efd5e15b37aedea3443d4a1e463e",
+          "title": "Learning and Computation of Φ-Equilibria at the Frontier of Tractability"
+        },
+        {
+          "paperId": "b88785362ad549f9e33ceed028b12e76f4b5dd5a",
+          "title": "Algorithmic contiguity from low-degree conjecture and applications in correlated random graphs"
+        }
+      ]
+    },
+    {
+      "paperId": "899bfbaab43764779cc9e4a9c800d71cc1f81f92",
+      "title": "The Capacity of Single-Server Weakly-Private Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "bc77948904abe5b8949d531c184cf4e2107326d1",
+          "title": "Device Independent Quantum Private Queries Based on Quantum Key Distribution"
+        },
+        {
+          "paperId": "d543d40262efdf23d1a24e7a8b63e5000ce59971",
+          "title": "Improving User Privacy in Practical Quantum Private Query with Group Honesty Checking"
+        },
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        },
+        {
+          "paperId": "09b73fe067ef51d335bc182675a352c997f09491",
+          "title": "Veriﬁable Secret Sharing Based on Fully Batchable Polynomial Commitment for Privacy-Preserving Distributed Computation"
+        },
+        {
+          "paperId": "8d17b38e0663c2e90d3b953d2699a16c9ee2cbfc",
+          "title": "Bandwidth-Efficient Two-Server ORAMs with O(1) Client Storage"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "0ef3d6951270bbac3724322890a4c8fb69eb5d7e",
+          "title": "Differentially Private Compression and the Sensitivity of LZ77"
+        },
+        {
+          "paperId": "c8cb0f9fd50ff326c3455f54aa81e34f155d61e2",
+          "title": "Uncoordinated Syntactic Privacy: A New Composable Metric for Multiple, Independent Data Publishing"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "af8bd8092c18095f474c5f4dff0037863e71a302",
+          "title": "Privacy-Preserving Data Sharing and Computing for Outsourced Policy Iteration with Attempt Records from Multiple Users"
+        },
+        {
+          "paperId": "de641d51e2129aca70f53193f547d26437a32262",
+          "title": "Trapdoor Hash Functions and PIR from Low-Noise LPN"
+        },
+        {
+          "paperId": "aa6d2b431f65a5ce9b81653cb4d8e23a02f809c1",
+          "title": "Theory and Applications of Sequentially Threshold Public-Key Cryptography: Practical Private Key Safeguarding and Secure Use for Individual Users"
+        }
+      ]
+    },
+    {
+      "paperId": "bd85cf3d9d70af2d48326f8153069a05f5183985",
+      "title": "The Capacity of Private Information Retrieval Under Arbitrary Collusion Patterns",
+      "recommendations": [
+        {
+          "paperId": "22303321a415b7f3a2f28c080adf9ddd8f4707f5",
+          "title": "Faster Spiral: Low-Communication, High-Rate Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "7ca8968083870150ddcd229bf056e00c348ff3b3",
+          "title": "Minicrypt PIR for Big Batches"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "134e62e78f04b2ae2366bb5a813276d5cdfaa4c7",
+          "title": "Optimal Differentially Private Sampling of Unbounded Gaussians"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "c7dc46bb698026279f4d1b40e21c40c5d579c9c8",
+          "title": "Tight Lower Bounds and New Upper Bounds For Evolving CDS"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "fcd9086b6aedf86310056eb1301dc86adfb7b0d0",
+          "title": "Dual-Source SPIR over a noiseless MAC without Data Replication or Shared Randomness"
+        },
+        {
+          "paperId": "31dbea5dacb2bb11573b534bcee9499a81d2346e",
+          "title": "Identification Under the Semantic Effective Secrecy Constraint"
+        },
+        {
+          "paperId": "64725a52c9c9fa21269bfc30a5b623271a53510b",
+          "title": "Byzantine Distributed Function Computation"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        },
+        {
+          "paperId": "e0687f8c142d336b8897509ed7083be264305031",
+          "title": "Rational Secret Sharing with Competition"
+        },
+        {
+          "paperId": "cdbf4a931878809adb9e33edf90adcb87dcced75",
+          "title": "Approximate Differential Privacy of the ℓ2 Mechanism"
+        },
+        {
+          "paperId": "ba149d81b23eba57a0b49556c02668eb2b76f796",
+          "title": "Eﬃcient veriﬁable searchable encryption with search and access pattern privacy"
+        },
+        {
+          "paperId": "8a45a9451e30076fca1699634c0dad6effbc7b96",
+          "title": "Distributed Non-Interactive Zero-Knowledge Proofs"
+        },
+        {
+          "paperId": "2f2d0e80345a9e4877a29d04db94cfbf7b715c63",
+          "title": "Eﬃcient top-k processing in large-scaled distributed environments"
+        },
+        {
+          "paperId": "855f90d0019bf502db29c41a523bec2784e4bd73",
+          "title": "Clubcards for the WebPKI: smaller certiﬁcate revocation tests in theory and practice"
+        },
+        {
+          "paperId": "2545acc0e2def1a5861219aab3b262d6a1d4bdab",
+          "title": "Privacy amplification by random allocation"
+        }
+      ]
+    }
+  ],
+  "mathematical physics": [
+    {
+      "paperId": "6311473c7c614ad29b5c0e6b94deec428219113f",
+      "title": "Asymptotic Methods in Equations of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "f7f21dda7101f2f5261202878ead97df8c1cae59",
+          "title": "NONLOCAL PROBLEMS FOR A MIXED PARABOLIC-HYPERBOLIC EQUATION OF THE THIRD ORDER"
+        },
+        {
+          "paperId": "39ad1eca0895611c3eb67eeab066e9fdd2a622ec",
+          "title": "Simple third order operator-splitting schemes for stochastic mechanics and field theory"
+        },
+        {
+          "paperId": "94604d1c33e97697434407aec5874dd3cf672c48",
+          "title": "On solvability of some boundary value problems for a nonlocal Poisson equation with periodic conditions"
+        },
+        {
+          "paperId": "4f077d26c6617b8494b0f6ec99866b2e3d3ac48a",
+          "title": "Recent advances about the rigorous integration of parabolic PDEs via fully spectral Fourier-Chebyshev expansions"
+        },
+        {
+          "paperId": "172ae625869fe557486b7fc8ae5481a009abd750",
+          "title": "Approximate Solution of a Linear Differential Equation with a Normal Operator"
+        },
+        {
+          "paperId": "8b9c52b951541d42f55a8ae5110a6808fca92392",
+          "title": "for Some Quasilinear Equations with Riemann – Liouville Derivatives and a Sectorial Operator"
+        },
+        {
+          "paperId": "058cbc23991be82bf808da0135bd475e0479450a",
+          "title": "Solution of nonlocal boundary value problems for the heat equation with discontinuous coefficients, in the case of two discontinuity points"
+        },
+        {
+          "paperId": "8c0e6348e63bb05af56f2aa5b3623006eb8634e8",
+          "title": "Persistence of hyperbolic solutions of ODE's under functional perturbations: Applications to the motion of relativistic charged particles"
+        },
+        {
+          "paperId": "b8916b8595cfd45331aa60994ad41caf962ef504",
+          "title": "A numerical method of solving the Cauchy problem for one differential equation with the Riemann – Liouville fractional derivative"
+        },
+        {
+          "paperId": "5cf29cb104aab057433015a8b85c20d877bd4e09",
+          "title": "A class of anisotropic diffusion-transport equations in non-divergence form"
+        },
+        {
+          "paperId": "670a58b159a28217843aa699cdb1a602a932026a",
+          "title": "CONDITIONS FOR SOLVABILITY AND COERCIVENESS OF A FOURTH-ORDER DIFFERENTIAL EQUATION WITH AN INTERMEDIATE COEFFICIENT"
+        },
+        {
+          "paperId": "d4c90628b63d7e967dc85fc9e0222c1faa425736",
+          "title": "On the constructive solvability of one class nonlinear integral equations of the Hammerstein type on the whole line"
+        },
+        {
+          "paperId": "6477d1d99096306acbd2552dc00ba4437004dddb",
+          "title": "CONSTRUCTION OF NORMAL SOLUTIONS FOR INHOMOGENEOUS PARTIAL DIFFERENTIAL EQUATIONS WITH IRREGULAR SINGULARITIES"
+        },
+        {
+          "paperId": "fc04122ca181687bc37b7f699b3d6ed72e03abfc",
+          "title": "Global Existence and Nonlinear Stability of Finite-Energy Solutions of the Compressible Euler-Riesz Equations with Large Initial Data of Spherical Symmetry"
+        },
+        {
+          "paperId": "3b6f3064497dbc9ae51741f5b738f30425769840",
+          "title": "Blow-up phenomena in a one-dimensional, bidirectional model equation for small-amplitude waves"
+        },
+        {
+          "paperId": "6a142565952ac2ba7d8e7f0d4d8bd52fda2054ae",
+          "title": "DIRICHLET TYPE PROBLEM FOR THE SYSTEM OF NONLINEAR BELTRAMI EQUATIONS WITH SINGULAR POINT"
+        },
+        {
+          "paperId": "b1a48d5fca1efb89b36bcf80c5327507c0808452",
+          "title": "Solution of the model problem of heat conduction with Bessel operator"
+        },
+        {
+          "paperId": "7c9a9f7d45312e8952e04767240b1c7184119ac3",
+          "title": "An asymptotic local finite-difference method for fractional Laplacian quasi-differential operator"
+        },
+        {
+          "paperId": "d4f271c4a489fc193917953167a89d7dcb23d890",
+          "title": "A uniformly accurate exponential wave integrator method for the nonlinear Klein-Gordon equation with highly oscillatory potential"
+        },
+        {
+          "paperId": "c2fb41c88359f633714e2be445cc03802c755919",
+          "title": "Study of the Solution of one Nonlinear Integro-differential Equation of Fourth Order."
+        }
+      ]
+    },
+    {
+      "paperId": "43cfaeca3d4dd1af8fa5e27754c47f050000c184",
+      "title": "Student’s need analysis in using ordinary differential equation e-module of Mathematical Physics II",
+      "recommendations": [
+        {
+          "paperId": "12116366691dc144a64126ea19b1e011b6cf3213",
+          "title": "Analysis of Mathematical Communication Skills of High School Students on Matrix Material"
+        },
+        {
+          "paperId": "7bf1368247a6fffdde38731bd4fcd519f1179250",
+          "title": "Analysis of Students' Mathematics Learning Outcomes on Matrix Concepts: A Comparative Study"
+        },
+        {
+          "paperId": "c0b9a3c5b2aed717e969b0d271fc4342f8fb9dcd",
+          "title": "Analysis of Students' Mathematical Problem-solving Ability on Number Matter"
+        },
+        {
+          "paperId": "5ae22fe72b0249d0e7134e95f74b5e1383ec276c",
+          "title": "The Effectiveness of the Realistic Mathematics Education Approach to Improve Students' Creativity in Learning Mathematics"
+        },
+        {
+          "paperId": "1cd6db00faca962c0fb5a957f50ba2916728fb39",
+          "title": "Resolving Learners Differences in the Learning of Mathematics"
+        },
+        {
+          "paperId": "0bdf9871f5eeade083cba45d281db3084c87ba99",
+          "title": "The Development of Module Based on Micro controller in Improving Student Computational Thinking Skills"
+        },
+        {
+          "paperId": "bc3414d32829153377cc17a2355631ef9aaa5088",
+          "title": "Descriptive Analysis of Student Learning Outcomes in Statistics Course"
+        },
+        {
+          "paperId": "0059ece079e90a034d4ec312d096cbdddc7b7fc9",
+          "title": "UPPER-SECONDARY STUDENTS' PROBLEM-POSING AND MATHEMATICAL MODELING SKILLS IN THE CONTEXT OF STEM EDUCATION AND 21ST CENTURY SKILLS"
+        },
+        {
+          "paperId": "2484c3ed4acdc14516d458cd1f8e474fbf899c45",
+          "title": "Study of student satisfaction with information support of educational activities"
+        },
+        {
+          "paperId": "c8025bf832e84eb6358331af90684631a945a8ad",
+          "title": "Analysis of Students' Critical Thinking Skills Profile on Momentum Impulse Material and Implementation of PBL Learning Model"
+        },
+        {
+          "paperId": "31edf7d61c735fdddb144edecf15bbca18c76ef0",
+          "title": "Analysis of the influence of the existence of national exams, school origin, and tutoring on mathematics motivation using decision tree"
+        },
+        {
+          "paperId": "a639566baf19092d184783e3077d3271376d4c40",
+          "title": "POSTGRADUATE STUDENTS’ PERCEPTION OF THEIR COMPETENCIES IN DESIGNING EDUCATIONAL RESEARCH: CASE OF THE UNIVERISTY OF NIGERIA, NSUKKA"
+        },
+        {
+          "paperId": "40cfdbcbe8f2461f1b55e3900fb8471da40f467b",
+          "title": "Effect of Mathematics Chapters’ Performance of the Students on Overall Performance of the Subject"
+        },
+        {
+          "paperId": "0284565e22ee4ace01d97bcb3957626e241761f1",
+          "title": "Mathematical Literacy in Algebra Content: The Trajectory of Students Conceptual Cognitive Style"
+        },
+        {
+          "paperId": "1d99bc2052df5ac03a7a3db02f4f383101f850f0",
+          "title": "Learning Barriers of the Grade 10 Students and Its Correlation to Their Conceptual Understanding in Mathematics"
+        },
+        {
+          "paperId": "4039aa73baa52252941ef11116a1c084a51c01dd",
+          "title": "Development of Interactive E-Modules for Elementary Students: Enhancing Learning Outcomes"
+        },
+        {
+          "paperId": "b7305620aca84638ab76c3eab4edbcc5b298a3db",
+          "title": "Improving critical thinking ability in elementary schools with interactive e-modules"
+        },
+        {
+          "paperId": "2774cfab3252b568a5f61a3e7b0e1577babcbff6",
+          "title": "DISPARITY BETWEEN APTITUDES AND THE CHOICE OF CAREERORIENTED COURSES AMONG STUDENTS IN IT COURSES"
+        },
+        {
+          "paperId": "4be3ebc9da211b685189df768794db6c45b77117",
+          "title": "The contribution of the “scientific literacy workshop\" on high school students' research attitudes"
+        },
+        {
+          "paperId": "fa9b7be6ca73ac3bca80f91abc352d4446528451",
+          "title": "First-Year Students' Understanding of The Use of Differential and Integral in Solving Kinematics Problems"
+        }
+      ]
+    },
+    {
+      "paperId": "757dd5fbc67d8f2591eb2077180af74c1797fcd1",
+      "title": "Methods of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "99aeaeb44d0e6d84b396b1014dfccbc077b0d336",
+          "title": "Mechanics of nature"
+        },
+        {
+          "paperId": "32531d62cc2c2caa8e3869d4932945e2e27c733e",
+          "title": "The rise of stochasticity in physics"
+        },
+        {
+          "paperId": "4617bfe4a65da6fed870256c4ce4b4c124aab23d",
+          "title": "Hidden symmetries in Hamiltonian geometry, topology, physics and mechanics"
+        },
+        {
+          "paperId": "895b57ecf7d84216b9b5129c4b34cfbc31b51630",
+          "title": "A brief introduction to fluctuation theorems: from theory to experiments"
+        },
+        {
+          "paperId": "071e77e491f66966e666e92d2a31cf6092005bc2",
+          "title": "Algebraic and Positive Geometry of the Universe: from Particles to Galaxies"
+        },
+        {
+          "paperId": "b609a13a08474eca865950ebe6e91c05e6bbe636",
+          "title": "Physical Interpretations of Integration Constants in the Solutions of Einstein Equations"
+        },
+        {
+          "paperId": "93f2561bf97403f8f645a1b4f0e4301f51380f3c",
+          "title": "A simple and uniﬁed explanation of modern physics"
+        },
+        {
+          "paperId": "c411696d0e2a4a25780fc7dd1068109f738ff1f3",
+          "title": "Physics and Complexity"
+        },
+        {
+          "paperId": "99f1b8a94548ee293230f05f0a69e42e585cff24",
+          "title": "Quantization of the electromagnetic field, entropy of an ideal monoatomic gas, and the birth of the Bose-Einstein statistics"
+        },
+        {
+          "paperId": "18c0c1d07a457f585090528cc37484d5d9641b8b",
+          "title": "The Reasonable Ineffectiveness of Mathematics in the Biological Sciences"
+        },
+        {
+          "paperId": "a2d92b1a81152b2e4ac1e996a68edc5ae0b24d21",
+          "title": "Fermi-Dirac and Bose-Einstein Distributions: An alternative approach"
+        },
+        {
+          "paperId": "8c0e6348e63bb05af56f2aa5b3623006eb8634e8",
+          "title": "Persistence of hyperbolic solutions of ODE's under functional perturbations: Applications to the motion of relativistic charged particles"
+        },
+        {
+          "paperId": "bd495ac1bf9d01b51f72bb75de85332bf5e81507",
+          "title": "A preliminary vocabulary of complexity"
+        },
+        {
+          "paperId": "0079f63c62d29f6e23d853cbb35f185877ebbc25",
+          "title": "The Born rule -- 100 years ago and today"
+        },
+        {
+          "paperId": "84ce2e2d04a186d3a015866c3748aef71ec93720",
+          "title": "QUANTUM MECHANICS FOR THE COMMON MAN"
+        },
+        {
+          "paperId": "aadf974f4a3a2c0f88095fb47810cc47f252ebf7",
+          "title": "The Birth of Quantum Mechanics: A Historical Study Through the Canonical Papers"
+        },
+        {
+          "paperId": "a9cf9a980daf4b1ef4a3260bd59b04b8acc942a0",
+          "title": "IS PHILOSOPHY NEEDED TO SOLUTION THE PROBLEMSOF MODERN PHYSICS? (RESPONDING TO STEPHEN HAWKING)"
+        },
+        {
+          "paperId": "e47e29fce56a5df7730ef797bd5671ff556ce5a0",
+          "title": "Uzbekistan mathematicians and their discoveries"
+        },
+        {
+          "paperId": "86eac419dc37277e5df05177f484f6ad5fed8c37",
+          "title": "God Does Not Play Dice"
+        },
+        {
+          "paperId": "bca60c5398b70b2cb07bb8dfc7a4da90a36c3864",
+          "title": "A thinking on Quantum Physics and common sense"
+        }
+      ]
+    },
+    {
+      "paperId": "f623f28e57448218a44e2f16e2a5e5161b008ec0",
+      "title": "On the Partial Difference Equations, of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "8069aaa6dccc013b5f29cf0508a713aa6c3d0170",
+          "title": "Methods for exact solutions of nonlinear ordinary differential equations\\"
+        },
+        {
+          "paperId": "eb614002bad8f179fd0f0c8e0a147f72e2ed55b2",
+          "title": "Approximation of a singular boundary value problem for a linear differential equation"
+        },
+        {
+          "paperId": "909dfca8ab22e1994cd09fb009fffc1a47de69f8",
+          "title": "Some methods for solving boundary value problems for polyharmonic equations"
+        },
+        {
+          "paperId": "e63e79033aaaa330df35a04c4f9403c083a1bd36",
+          "title": "Mathematical and numerical analysis for some nonlinear second-order ordinary differential equations of Duffing type"
+        },
+        {
+          "paperId": "bb027a6ba8f6d8cc59d3b49d9201f5a2fa3de5c0",
+          "title": "Introduction to inverse problems for non-linear partial differential equations"
+        },
+        {
+          "paperId": "04632fda02c324f1ff60001ec9412e6179e88828",
+          "title": "An analysis of the nonlinearizable classes of Emden-Liénard equations"
+        },
+        {
+          "paperId": "3212f3a8a3eb250447cf771c021759e3c498ba7a",
+          "title": "On stability of linear autonomous difference equations with complex coefficients"
+        },
+        {
+          "paperId": "0bcabd51e9df190be3765eda6c1cd28ff6a3d729",
+          "title": "Reducing of system of partial differential equations and generalized symmetry of ordinary differential equations"
+        },
+        {
+          "paperId": "6c789b49aee01fd72dec3e0d50c16e9889d370e7",
+          "title": "Comparison Between Two Methods to Find Exact Solutions for a New Models of Nonlinear Partial Differential Equations"
+        },
+        {
+          "paperId": "acf9eaa206aceda03c87a8711b6ebdab6dc9e64a",
+          "title": "Coupled general Riemann problems for the Euler equations"
+        },
+        {
+          "paperId": "6477d1d99096306acbd2552dc00ba4437004dddb",
+          "title": "CONSTRUCTION OF NORMAL SOLUTIONS FOR INHOMOGENEOUS PARTIAL DIFFERENTIAL EQUATIONS WITH IRREGULAR SINGULARITIES"
+        },
+        {
+          "paperId": "54bbdb16f191435731c864a0c25e8962566622f8",
+          "title": "Formation of Singularities for Hyperbolic Differential Equations With Geometric Backgrounds"
+        },
+        {
+          "paperId": "03bb5b650356d7e02daf083f398a6b218a25026a",
+          "title": "Solutions of inhomogeneous linear difference equations using Green's functions"
+        },
+        {
+          "paperId": "acdeaca459bdb7d036b02b3336f8cfcf1017467b",
+          "title": "Fredholm Integral Equation Solving by Different Methods"
+        },
+        {
+          "paperId": "5763523702d605bd312ba4d89f7083d12b16ff08",
+          "title": "Solving elliptic and parabolic partial differential equations using Excel"
+        },
+        {
+          "paperId": "06258790d83f55e47106378edd8a6e93233dfc55",
+          "title": "Hybrid Iterative Methods for Solving Nonlinear Equations in Banach Spaces"
+        },
+        {
+          "paperId": "0f153777810de3225887918f4da5945bd01317f0",
+          "title": "Second-order differential equations with mixed neutral terms: new oscillation theorems"
+        },
+        {
+          "paperId": "3f78a0609fcdf24aa5ea5e01d31db16a88ec89d2",
+          "title": "Milstein Approximation for Free Stochastic Differential Equations"
+        },
+        {
+          "paperId": "abf8670f7ceea31fcf2b312a2989d0620649dce0",
+          "title": "Inverse boundary value problem for a linearized equations of longitudinal waves in rods"
+        },
+        {
+          "paperId": "0f36bfd9c7d2e35408370d8d324b15f44dd573b5",
+          "title": "A Technique to Solve a Parabolic Equation by Point Symmetries that Incorporate Initial Data"
+        }
+      ]
+    },
+    {
+      "paperId": "bd28034c0eade916356abb7545c843e02385b5ee",
+      "title": "Formulas and Theorems for the Special Functions of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "84d9e41383c67350285aad7dbbf29fc50c169381",
+          "title": "Elegance, Facts, and Scientiﬁc"
+        },
+        {
+          "paperId": "43ce644bb7ffad5d949a6c9e298b0da498a42a0b",
+          "title": "The Sampling Theorem and the Lerche–Newberger Formula"
+        },
+        {
+          "paperId": "f6e8eb62ce571c5b11c4cb6c80d7b2031ac15c7b",
+          "title": "The Change of Variable Formula Integrals, do they have equal value?"
+        },
+        {
+          "paperId": "c411696d0e2a4a25780fc7dd1068109f738ff1f3",
+          "title": "Physics and Complexity"
+        },
+        {
+          "paperId": "f0ae5201887b56658c4e32cb1194e7cf9084e6ac",
+          "title": "Dependence of functions on their variables"
+        },
+        {
+          "paperId": "3679e4f7d984f2b11ff3473bfdf84f57a47881f9",
+          "title": "Introduction to Proof Theory"
+        },
+        {
+          "paperId": "179e122c5de71588f45905a11cd857ca6b91210c",
+          "title": "Optimality and Renormalization imply Statistical Laws"
+        },
+        {
+          "paperId": "dd573b35d7fad5b8f8dacadf50ef8aa3390919fc",
+          "title": "The Measure of a Mass"
+        },
+        {
+          "paperId": "7b4662c2e9521323ae976571132fcca72ccbb9cc",
+          "title": "Elementary Proof of the Completeness of OEIS A051221 Below 2000"
+        },
+        {
+          "paperId": "702f7cd0127c1ab259adbab0bf86c0ef1427f751",
+          "title": "THE POSSIBLE CONSISTENCY OF 𝑃 ≠ 𝑁𝑃 WITH ZFC"
+        },
+        {
+          "paperId": "b5a25ec6f80cb5534a21f34092105b352c0958b3",
+          "title": "The Great Rift in Physics"
+        },
+        {
+          "paperId": "8e88cc251bc75877a20731b27c9bd5913e8eeae1",
+          "title": "On decoupling and restriction estimates"
+        },
+        {
+          "paperId": "b1f366e1e617fdb094dd1d1b1193201d89d7b412",
+          "title": "Wittgenstein and concept‐extension in mathematics"
+        },
+        {
+          "paperId": "cc32b4e71b9b3fe4053fb70a826fc2eb586c445e",
+          "title": "A note on generalized generalization"
+        },
+        {
+          "paperId": "ba1a3495828efb4d56ceeb315f349902f8bb85a5",
+          "title": "Establishing the Fundamental Theorem of Arithmetic"
+        },
+        {
+          "paperId": "fc393d7f79884818230755f31b9ec963765f90a4",
+          "title": "BOOK REVIEW"
+        },
+        {
+          "paperId": "66523b466868e3c748287adac08640d9c1a5cbd1",
+          "title": "The Recursive Mathematical Lock: A Final Unified Proof of the Seven Millennium Problems"
+        },
+        {
+          "paperId": "0d9a3a613e5bb837e29f1c3136bd1d01c0ccb254",
+          "title": "Graphical functions with spin"
+        },
+        {
+          "paperId": "594b27837f89078d73f7062f0fd759dc6678280d",
+          "title": "Resolution of singularities for the dynamical mathematician"
+        },
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        }
+      ]
+    },
+    {
+      "paperId": "80ae31c9d9dc9d5bdd3f92a98418d157b64d2bfb",
+      "title": "Methods of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "ee6a62198160982f74ce954de404ecd18cf8d7b1",
+          "title": "Theorems on the zeros of linear differential operators"
+        },
+        {
+          "paperId": "78b485f49e1738be80b6a4f1ec7ae913e47751f0",
+          "title": "On computing the zeros of a class of Sobolev orthogonal polynomials"
+        },
+        {
+          "paperId": "bf2281b24c0b5620f1abdb90d7931ee170621b7c",
+          "title": "Asymptotics and zeros of a special family of Jacobi polynomials"
+        },
+        {
+          "paperId": "3a8131ad4d84c0eb274fcc7b2e75b164e8b09133",
+          "title": "Multiple orthogonal polynomial ensembles of derivative type"
+        },
+        {
+          "paperId": "9e84fc6e501e18046b451f9b71af7170dfd521c5",
+          "title": "Minimization of the norm of the error functional of one quadrature formula"
+        },
+        {
+          "paperId": "3af41541e6260cdf047276f939c3ee41f6d9142d",
+          "title": "Matrix Bessel Biorthogonal Polynomials: A Riemann-Hilbert approach"
+        },
+        {
+          "paperId": "92a8141888fab4523f74e1bd2ea5b98c9a57de42",
+          "title": "A Spectral Theory of Scalar Volterra Equations"
+        },
+        {
+          "paperId": "bfe6ec3821c09f29b0aa3962f79e62a5a00ef3c0",
+          "title": "Topological Entropy of Regular Chaotic Quadratic Maps"
+        },
+        {
+          "paperId": "dcfecb74db1e6f7840348481d0aa035d6b9f74f6",
+          "title": "Linear Instability of the Prandtl Equations via Hypergeometric Functions and the Harmonic Oscillator"
+        },
+        {
+          "paperId": "8b8d5923119f6cdb9ff12e94b761e96c3769d8bf",
+          "title": "Analytical properties of derivative polynomials"
+        },
+        {
+          "paperId": "f3f0f490c03222e30eb2023765b15a352e3a2f44",
+          "title": "Nonlinear eigenvalue problems for seminorms and applications"
+        },
+        {
+          "paperId": "98e9528ccd2aff6a7576e0247f4d6906bc1e9c34",
+          "title": "Hilbert-Kamke equations and geometric designs of degree five for classical orthogonal polynomials"
+        },
+        {
+          "paperId": "b24d833cf56379d31f4754cce5cd453aa18f3f95",
+          "title": "Duality theorems for polyanalytic functions"
+        },
+        {
+          "paperId": "172ae625869fe557486b7fc8ae5481a009abd750",
+          "title": "Approximate Solution of a Linear Differential Equation with a Normal Operator"
+        },
+        {
+          "paperId": "f72c39670129b5b06f5ac460f8fe8e68cec47030",
+          "title": "Decomposition results for multiplicative actions and applications"
+        },
+        {
+          "paperId": "c46e41f00da4d29325690ecbee40d487d61f639d",
+          "title": "Zeros of orthogonal polynomials and some matrix inequalities"
+        },
+        {
+          "paperId": "467b6b8b428966d6adfefe51018d0b9de3e876a0",
+          "title": "Hammerstein Nonlinear Integral Equations and Iterative Methods for the Computation of Common Fixed Points"
+        },
+        {
+          "paperId": "32b00467ed393593c279fa853cd85dc4f3876c5d",
+          "title": "Traveling-Wave Solutions of Several Nonlinear Mathematical Physics Equations"
+        },
+        {
+          "paperId": "8a0c3fb8fe92ff13e5f17d05bd661dfe515780ad",
+          "title": "Application of methods of quasicrystals theory to entire functions of exponential growth"
+        },
+        {
+          "paperId": "d42b9d5b0d9d949b5aea3601d18fc2084f4e9774",
+          "title": "Exploration on the numerical range and spectral constants of the Volterra operator"
+        }
+      ]
+    },
+    {
+      "paperId": "941e6fba6deda7d2193fa1d1ab357f3f72cb33c7",
+      "title": "Situation analysis of mathematical physics learning with online learning during the COVID-19 pandemic",
+      "recommendations": [
+        {
+          "paperId": "7253ba8085ec46e3546ab4f793e1d4dbbf1328e7",
+          "title": "Analysis of the multirepresentation ability of physics education students in problem-solving related to physics"
+        },
+        {
+          "paperId": "f4a57ebb977c31e14ac526ca71bce849267913ab",
+          "title": "University mathematics lecturers’ experiences of teaching and learning during COVID-19 pandemic: A comparative study between Kuwait and United Kingdom"
+        },
+        {
+          "paperId": "72acfd11fcec2b77dc7b0faff15ba374f6a1dea8",
+          "title": "The Impact of the COVID-19 Pandemic upon Mathematics Assessment in Higher Education"
+        },
+        {
+          "paperId": "7f22e0943108660335b79b78bc9a2cf676b01b24",
+          "title": "The Impact of COVID 19 pandemics and Online Learning on Medical Students’ Academic Achievement"
+        },
+        {
+          "paperId": "c5d08b8702117a576f8cbddecb0af61b38436206",
+          "title": "Effectiveness of Video Lessons in Improving the Numeracy Level of Grade 7 Students Amidst Pandemic"
+        },
+        {
+          "paperId": "c109d219f4d324c9a851567fb616cc58a0d83b4f",
+          "title": "Challenges Encountered in Teaching Four Basic Operations in Mathematics and Academic Performance among Pupils"
+        },
+        {
+          "paperId": "ae6fb19c84a3780fc5de8b55e0cb97d0592d5ce0",
+          "title": "The Impact of Problem-Based Learning on Mathematics Education: A Systematic Literature Review"
+        },
+        {
+          "paperId": "010085a556f080c8ed822a62fb722413a74c1a98",
+          "title": "Contextual Teaching of Engineering Mathematics to Improve Levels of Accuracy and Confidence in COVID-19 Knowledge"
+        },
+        {
+          "paperId": "1cd6db00faca962c0fb5a957f50ba2916728fb39",
+          "title": "Resolving Learners Differences in the Learning of Mathematics"
+        },
+        {
+          "paperId": "0c6da576acccbb362a23afca6ee72055ab33c1ae",
+          "title": "Mathematical Challenges in Biology: Identifying Core Learning Difficulties"
+        },
+        {
+          "paperId": "0327f693ffc16bcc2a9248fc5e71dd73cefb230a",
+          "title": "Challenges and Prospects of Online Learning during and Post Covid-19 Pandemic"
+        },
+        {
+          "paperId": "83f556a58d9849508141d4c51406b37b6aeeccbb",
+          "title": "Understanding Student Struggles: The Phenomenon of Objectification in Indonesian Online Education During the COVID-19 Pandemic"
+        },
+        {
+          "paperId": "463a49162dd2f4f3c98ddd6c7d7c44386ca6fa73",
+          "title": "Analysis of Student Needs for Interactive Physics Learning Module Based on Agricultural Systems at SMK Negeri Luyo"
+        },
+        {
+          "paperId": "eafa635655879b3758618cbd74edced4d5ef4383",
+          "title": "Effectiveness of Jigsaw Classroom Strategy in Learning Mathematics"
+        },
+        {
+          "paperId": "c0b9e158882cea1fc05480110c81c2a23940f1cf",
+          "title": "The Influence of the Reciprocal Teaching Learning Model Assisted by Student Worksheets (LKPD) on Students Mathematical Communication Ability"
+        },
+        {
+          "paperId": "9aef10652efb27d8aa4aaf655184538af31a64a7",
+          "title": "Multirepresentation in Physics Learning Research: A Content Analysis Review of Trends, Opportunities, and Challenges"
+        },
+        {
+          "paperId": "14988f1239e534ebe0b1d88b9fe7b31c6d5d79bc",
+          "title": "Students’ Motivation, Learning Strategies, and Math Performance in the Modular Distance Learning During the COVID-19 Pandemic"
+        },
+        {
+          "paperId": "0de34290c8aa401548253fea2ecbcb566b33863b",
+          "title": "THE INFLUENCE OF GUIDED INQUIRY LEARNING MODEL ON STUDENTS' LEARNING OUTCOMES IN VIRUS TOPIC"
+        },
+        {
+          "paperId": "628eb8875e2dc6f704b9fb07173828b9136c8cd2",
+          "title": "College Students’ Remote Learning Experiences in Functional English"
+        },
+        {
+          "paperId": "766902131bf6db1ab0f3df36881ac8cb668282d5",
+          "title": "The Impact of the Discovery Learning Model on Mathematical Communication Skills and Study Habits of Junior High School Students"
+        }
+      ]
+    },
+    {
+      "paperId": "15fe0cc00822ec826441bb100050342aa996d343",
+      "title": "Vieta–Lucas polynomials for solving a fractional-order mathematical physics model",
+      "recommendations": [
+        {
+          "paperId": "1247b981e8f98abed4d9b7306d2c8d99a88868ad",
+          "title": "Numerical Solution of 2D Nonlinear Volterra-Fredholm Integral Equations using Polynomial Collocation Method"
+        },
+        {
+          "paperId": "5358b85c7444ac9d4fef1bd5936647dac016d5a5",
+          "title": "New Method for Solving Fractional Differential Equations: HK Transform"
+        },
+        {
+          "paperId": "2aacb0f303648a9a1be716abf1a9bdb37f271a47",
+          "title": "Müntz–Legendre Wavelet Collocation Method for Solving Fractional Riccati Equation"
+        },
+        {
+          "paperId": "f3f51931d0bd7296bdd9f01940e05d579cdcb288",
+          "title": "A Matrix Approach by Convolved Fermat Polynomials for Solving the Fractional Burgers’ Equation"
+        },
+        {
+          "paperId": "236bdad2839cbac3a1a2d1621a7db2266149b5a3",
+          "title": "An anisotropic nonlinear stabilization for finite element approximation of Vlasov-Poisson equations"
+        },
+        {
+          "paperId": "bc4220fdb7be47da48fb8e4de7f915c45adc345f",
+          "title": "A global method for solving second-kind Volterra–Fredholm integral equations"
+        },
+        {
+          "paperId": "c74034581eaadfe20247b2a7a9fce60a6202151a",
+          "title": "Linearized fractional Adams scheme for Fractional Allen-Cahn equations"
+        },
+        {
+          "paperId": "ec41a1dd8ec7f6deafa3a0aa4d09cefaab3c7eb2",
+          "title": "An Approximate Analytical View of Fractional Physical Models in the Frame of the Caputo Operator"
+        },
+        {
+          "paperId": "0da22aa3dd4b30ed894557a31153de358f327e6e",
+          "title": "Tempered Riemann–Liouville Fractional Operators: Stability Analysis and Their Role in Kinetic Equations"
+        },
+        {
+          "paperId": "e7158a7f06efee1ac18f1fa4ad23366c20d19a25",
+          "title": "A Novel Approach to Solve Nonlinear Higher Order Fractional Volterra–Fredholm Integro‐Differential Equations Using Laplace Adomian Decomposition Method"
+        },
+        {
+          "paperId": "70d6a5f41ad2a959841bfcc5cc06a31ff9fa3db8",
+          "title": "On the Pseudospectral Method for Solving the Fractional Klein–Gordon Equation Using Legendre Cardinal Functions"
+        },
+        {
+          "paperId": "495f6cf7dd6033146207ad5239ce6558b5b6284b",
+          "title": "An effective operational matrix method based on shifted sixth-kind Chebyshev polynomials for solving fractional integro-differential equations with a weakly singular kernel"
+        },
+        {
+          "paperId": "d7a92c2aef0070cfc57a483b3e44f93893ddb3b2",
+          "title": "Solving Volterra Integro-Differential Equations of Fractional Order Using Perturbation Collocation Method"
+        },
+        {
+          "paperId": "9951169d8ef1e58ad1fea6a66a4f21fe46a2b4c3",
+          "title": "A numerical Bernstein splines approach for nonlinear initial value problems with Hilfer fractional derivative"
+        },
+        {
+          "paperId": "2b8cb526b42703c40bde909d6afc6aea8ff67e22",
+          "title": "Numerical study of the non-linear time fractional Klein-Gordon equation using the Pseudo-spectral method"
+        },
+        {
+          "paperId": "17c0c23ef6514698a0c2264bb3085355328fe13f",
+          "title": "A barycentric Floater-Hormann interpolation with time splitting for numerical simulation of multi-dimensional regularized long wave equation"
+        },
+        {
+          "paperId": "9d41aa10b3d90226100d5b8c8b3c7e3df289147b",
+          "title": "Numerical study of soliton behavior of generalised Kuramoto-Sivashinsky type equations with Hermite splines"
+        },
+        {
+          "paperId": "0f0ee1d9cb8f2406fabbaf41abcbfe4c4677a528",
+          "title": "A Novel Fractional Integral Transform-Based Homotopy Perturbation Method for Some Nonlinear Differential Systems"
+        },
+        {
+          "paperId": "5c0be6bd70bd0201c396344ac6b30ca54a6509c5",
+          "title": "Application of modiﬁed extended direct algebraic method to nonlinear fractional diffusion reaction equation with cubic nonlinearity"
+        },
+        {
+          "paperId": "e22c91457dc26f067b9f08ab8652599631a2c648",
+          "title": "A Novel Algorithm for Solving Fredholm Integro-Differential Equations Using Lucas Polynomials"
+        }
+      ]
+    },
+    {
+      "paperId": "4bd5f2f580a49851d33fba64b9a3dbe635eb41d9",
+      "title": "Students' Perceptions of Mathematical Physics E-Module on Multiple Integral Material",
+      "recommendations": [
+        {
+          "paperId": "7253ba8085ec46e3546ab4f793e1d4dbbf1328e7",
+          "title": "Analysis of the multirepresentation ability of physics education students in problem-solving related to physics"
+        },
+        {
+          "paperId": "7bf1368247a6fffdde38731bd4fcd519f1179250",
+          "title": "Analysis of Students' Mathematics Learning Outcomes on Matrix Concepts: A Comparative Study"
+        },
+        {
+          "paperId": "1cd6db00faca962c0fb5a957f50ba2916728fb39",
+          "title": "Resolving Learners Differences in the Learning of Mathematics"
+        },
+        {
+          "paperId": "5ae22fe72b0249d0e7134e95f74b5e1383ec276c",
+          "title": "The Effectiveness of the Realistic Mathematics Education Approach to Improve Students' Creativity in Learning Mathematics"
+        },
+        {
+          "paperId": "fcec88a9c95f4c8b4dfed87509179a6e5a85b01e",
+          "title": "Supporting the Transition Between Mathematics and Physics in the First Year of University"
+        },
+        {
+          "paperId": "05152a0bebe67c7f30be0db09899b6da5668ec9d",
+          "title": "Students’ understanding of two-variable calculus concepts in mathematics and physics contexts. II. The gradient and the Laplacian"
+        },
+        {
+          "paperId": "ae6fb19c84a3780fc5de8b55e0cb97d0592d5ce0",
+          "title": "The Impact of Problem-Based Learning on Mathematics Education: A Systematic Literature Review"
+        },
+        {
+          "paperId": "531926e601186a718e0aa735f4d7605452f61935",
+          "title": "Examination of the Effects of STEM Activities in Physics Subjects on Students’ Attitudes and Problem-Solving Skills"
+        },
+        {
+          "paperId": "deb4f2b4f66fd04f5bb3baf96962439091a5cd2d",
+          "title": "Exploring the Implementation of Modern Physics Practicum to Enhance the Science Process Skills of Indonesian Physics Education Students"
+        },
+        {
+          "paperId": "0284565e22ee4ace01d97bcb3957626e241761f1",
+          "title": "Mathematical Literacy in Algebra Content: The Trajectory of Students Conceptual Cognitive Style"
+        },
+        {
+          "paperId": "6fd46d0b60d46a3b96b4c5f724b401c3b9bd53b9",
+          "title": "Investigating Learning Obstacles In Mathematical Literacy: A Study On Linear Equations With One Variable"
+        },
+        {
+          "paperId": "2b1c5ae9fe1b5363d41f876e877fd1a29ce777e2",
+          "title": "An Analysis Identification of Physics Student Critical Thinking and Creative Thinking Skill in Physics Learning"
+        },
+        {
+          "paperId": "1d99bc2052df5ac03a7a3db02f4f383101f850f0",
+          "title": "Learning Barriers of the Grade 10 Students and Its Correlation to Their Conceptual Understanding in Mathematics"
+        },
+        {
+          "paperId": "05e4847e0ae01771c6215046674cd968e1d78a69",
+          "title": "Investigating the effect of teaching kinematics concepts using thought experiments on students’ academic progress and learning strategies"
+        },
+        {
+          "paperId": "01583b6b07ca6782e01d98c4555c9c8f84d0d2fe",
+          "title": "Conformity of Intellectual Development and Constructivism Textbooks of Science-Based Physics"
+        },
+        {
+          "paperId": "cc5f4461f34b716f19433c2f6a0ac8c637758887",
+          "title": "Research on the Effectiveness of Teaching the Course «Аtomic Physics» Based on STEM Education"
+        },
+        {
+          "paperId": "fc87223ae27c4eb9faf8a2c28eb7cf8b87b2b15b",
+          "title": "Undergraduate students’ understanding of the application of integral calculus in kinematics"
+        },
+        {
+          "paperId": "7847b4a61bc093834a828ccb0ead8d4b167af208",
+          "title": "COGNITIVE APPRENTICESHIP INSTRUCTIONAL STRATEGY AND STUDENTS’ INTEREST IN PHYSICS"
+        },
+        {
+          "paperId": "8e13112b4175b151d11f9fe1d760aa7390ad3101",
+          "title": "The Effect of the Implementation of the ICARE Learning Model on the Physics Learning Outcomes of Students of Class XII IPA"
+        },
+        {
+          "paperId": "c8025bf832e84eb6358331af90684631a945a8ad",
+          "title": "Analysis of Students' Critical Thinking Skills Profile on Momentum Impulse Material and Implementation of PBL Learning Model"
+        }
+      ]
+    },
+    {
+      "paperId": "3db28306174110150a4d7c61b5c9b0b392bd652c",
+      "title": "General improved Kudryashov method for exact solutions of nonlinear evolution equations in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "3db1072f24012a289e5b6a6637b5ecebb3bb7c8d",
+          "title": "New Exact Solutions for Coupled Korteweg-de Varies-Zakharov-Kuznetsov Equation and Modified Korteweg-de Varies-Zakharov-Kuznetsov Equation"
+        },
+        {
+          "paperId": "b026e4e8d55d137c1c53b0f5917dd1b0be05220a",
+          "title": "Exact Solutions to New Potential Nonlinear Partial Differential Equations Using Extended Generalized Riccati Equation Mapping Method"
+        },
+        {
+          "paperId": "7b325640cb5ed1fcd35ffa9a3cba6846c878d34b",
+          "title": "Bifurcations and exact solutions of generalized nonlinear Schrödinger equation"
+        },
+        {
+          "paperId": "f4fe7473e65b6a316f8c982e06711158306d7838",
+          "title": "The analysis of the traveling wave solutions of the Hirota-Ramani equation via the modified Kudryashov method"
+        },
+        {
+          "paperId": "0602f7b9a6d355ee3090153f83f8ccb762161fd5",
+          "title": "Bifurcations and Exact Solutions for the Perturbed Gerdjikov–Ivanov Model with Full Nonlinearity"
+        },
+        {
+          "paperId": "6c789b49aee01fd72dec3e0d50c16e9889d370e7",
+          "title": "Comparison Between Two Methods to Find Exact Solutions for a New Models of Nonlinear Partial Differential Equations"
+        },
+        {
+          "paperId": "e63e79033aaaa330df35a04c4f9403c083a1bd36",
+          "title": "Mathematical and numerical analysis for some nonlinear second-order ordinary differential equations of Duffing type"
+        },
+        {
+          "paperId": "5c0be6bd70bd0201c396344ac6b30ca54a6509c5",
+          "title": "Application of modiﬁed extended direct algebraic method to nonlinear fractional diffusion reaction equation with cubic nonlinearity"
+        },
+        {
+          "paperId": "97ab9a6a90eeba8bc3dd5bb4b644c481dab61afd",
+          "title": "Asymptotic stability of N-soliton solutions for the modified nonlinear Schrödinger equation"
+        },
+        {
+          "paperId": "51172ac58f6c0dde7bce95fdfb460efd22ede5ea",
+          "title": "New Traveling Wwaves Solutions for Combined Zakharov Kuznetsov-Equal Width Equation and Zakharov Kuznetsov-Modified Equal Width Equation"
+        },
+        {
+          "paperId": "8069aaa6dccc013b5f29cf0508a713aa6c3d0170",
+          "title": "Methods for exact solutions of nonlinear ordinary differential equations\\"
+        },
+        {
+          "paperId": "297fca1a5b16fcd7686d2fcdaee73439c3fbbbc2",
+          "title": "Quasilinear Schrödinger equations with linear growth: Existence and asymptotic behavior of soliton solutions"
+        },
+        {
+          "paperId": "11db1f71c02a95cd75eb7a5091de6f6d30642681",
+          "title": "Series Solution and Wave Solution of Time Fractional Generalized Korteweg-de Vries Equation"
+        },
+        {
+          "paperId": "7a9f58b71fd98a7d1a5e106808151de117ed63df",
+          "title": "Exploring soliton solutions of Zakharov–Kuznetsov dynamical model with applications"
+        },
+        {
+          "paperId": "236bdad2839cbac3a1a2d1621a7db2266149b5a3",
+          "title": "An anisotropic nonlinear stabilization for finite element approximation of Vlasov-Poisson equations"
+        },
+        {
+          "paperId": "04d05ada2bb17a851ed210ea3aff8b69ba930003",
+          "title": "Exact Solutions and Classification of the (1+3) Dimensional Generalized Modified Schrödinger Equation Using Symmetry Reduction Approach"
+        },
+        {
+          "paperId": "32b00467ed393593c279fa853cd85dc4f3876c5d",
+          "title": "Traveling-Wave Solutions of Several Nonlinear Mathematical Physics Equations"
+        },
+        {
+          "paperId": "1247b981e8f98abed4d9b7306d2c8d99a88868ad",
+          "title": "Numerical Solution of 2D Nonlinear Volterra-Fredholm Integral Equations using Polynomial Collocation Method"
+        },
+        {
+          "paperId": "131a35569f3e00b96f2a4d92f834274ad63e2d1f",
+          "title": "Solitary Wave Solutions of the coupled Kawahara Equation"
+        },
+        {
+          "paperId": "4c1c46d0b50576d99ef723445f898cf69216b671",
+          "title": "Explicit and accurate solutions for the Benney equation"
+        }
+      ]
+    },
+    {
+      "paperId": "3f69ae55f522cbd2969a78f8a4ff1aa5a317ed5c",
+      "title": "The Wright Functions of the Second Kind in Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "2c644b4b21a35cb0ab7d0c5a2b4632941d2a8d70",
+          "title": "Abundant Elliptic, Trigonometric, and Hyperbolic Stochastic Solutions for the Stochastic Wu–Zhang System in Quantum Mechanics"
+        },
+        {
+          "paperId": "f140e54ceb215e519b3cfde3c3d4e29af80b4d73",
+          "title": "Properties of the Dirichlet Green's function for linear diffusions on a half line"
+        },
+        {
+          "paperId": "1773f7f9f71897013d53a7c739f0463aadf29f4f",
+          "title": "Simulation of infinite-dimensional diffusion bridges"
+        },
+        {
+          "paperId": "1ede6e6f3d8d6e8356cb76cfeca834bbd7b1b085",
+          "title": "On propagation of exponential moments"
+        },
+        {
+          "paperId": "43ce644bb7ffad5d949a6c9e298b0da498a42a0b",
+          "title": "The Sampling Theorem and the Lerche–Newberger Formula"
+        },
+        {
+          "paperId": "e9a451953624dfa20a1c899b219e2ab2bf5d195f",
+          "title": "Decoupling and decay of two-point functions in a two-species TASEP"
+        },
+        {
+          "paperId": "ea207b80b43e3bf5abc20685b7e586e8c8d90da9",
+          "title": "The global attractor of the inelastic linear Boltzmann equation in a gravity field for Maxwell molecules"
+        },
+        {
+          "paperId": "00372cb43a4f85364b46fab5dbc15bee9a83b1af",
+          "title": "Two-term Kummer function solutions of the 1D Schrödinger equation"
+        },
+        {
+          "paperId": "6783716ca6dee34dca222ec42d6f17a20c61c150",
+          "title": "Positive Normalized Solutions to a Kind of Fractional Kirchhoff Equation with Critical Growth"
+        },
+        {
+          "paperId": "0f2970d1c3feb06d8ca4a6ac373c1160a3e65ab9",
+          "title": "A Class of Subcritical and Critical Schrödinger–Kirchhoff Equations with Variable Exponents"
+        },
+        {
+          "paperId": "a0b2c433fd170596b41dbc7d4f6d90e08de82d6c",
+          "title": "On the well-posedness of a certain model with the bi-Laplacian appearing in the Mathematical Biology"
+        },
+        {
+          "paperId": "d2973d43f914e423b15c7f5ab02dcab723bcf204",
+          "title": "NON-LOCAL PHASE TRANSITIONS WITH SINGULAR ANISOTROPIC KERNELS"
+        },
+        {
+          "paperId": "079958e3d239f0bf975c3eda09b16db66c96da01",
+          "title": "Nonstandard representation of the Dirichlet form and application to the comparison theorem"
+        },
+        {
+          "paperId": "7fd4cd3c694fbfeaf97c2fe2bbc57c76915871b3",
+          "title": "Regularity of solutions of Fokker-Planck equations with rough coeﬃcients"
+        },
+        {
+          "paperId": "73b5f181ba685b0d23792d1c82c9d558bb8c0750",
+          "title": "Trace operators for Riemann--Liouville fractional equations"
+        },
+        {
+          "paperId": "5f8027252448748eb2bb0fc51f83a7695baa674a",
+          "title": "Long time semiclassical propagation in a perturbed cat map"
+        },
+        {
+          "paperId": "29413460e0d1dc2cdf442b0b7080b7e58681d610",
+          "title": "Invariant measures of stochastic Klein–Gordon–Schrödinger equations on infinite lattices"
+        },
+        {
+          "paperId": "64142300e300f6f70e3fc2894fc0e170f7c32c00",
+          "title": "Parametrised KAM Theory, an Overview"
+        },
+        {
+          "paperId": "b6f6ef661732f7b83e461f891262c8e4b5ca42d8",
+          "title": "Global weak solutions of the Navier-Stokes-Korteweg Equations in one dimension"
+        },
+        {
+          "paperId": "98e1c6ac65e339189d4fdb985b74d992e3eaeca5",
+          "title": "Weak Error of Dean-Kawasaki Equation with Smooth Mean-Field Interactions"
+        }
+      ]
+    },
+    {
+      "paperId": "ac8cdc28a8a750ce844a76dc5f27c638fcf4673d",
+      "title": "Exact wave solutions to the simplified modified Camassa-Holm equation in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "f4fe7473e65b6a316f8c982e06711158306d7838",
+          "title": "The analysis of the traveling wave solutions of the Hirota-Ramani equation via the modified Kudryashov method"
+        },
+        {
+          "paperId": "47e301c7a9ec9aaaee814ad68de7894bf8974e37",
+          "title": "New Analytical Wave Structures for the (2+1)-Dimensional Chaffee-Infante Equation"
+        },
+        {
+          "paperId": "7b325640cb5ed1fcd35ffa9a3cba6846c878d34b",
+          "title": "Bifurcations and exact solutions of generalized nonlinear Schrödinger equation"
+        },
+        {
+          "paperId": "9754eee9f128eeedd6933fe901ba2d1ead80048b",
+          "title": "Exact Solution for Nonlinear Acoustics Model with Conformable Derivative"
+        },
+        {
+          "paperId": "ff7706a4e9e7dc963b8619eaf2457e90668e1474",
+          "title": "AN ADAPTED ANALYTICAL SOLUTION TO THE MULHOLLAND EQUATION: MODIFIED DIRECT ITERATION PROCEDURE"
+        },
+        {
+          "paperId": "04d05ada2bb17a851ed210ea3aff8b69ba930003",
+          "title": "Exact Solutions and Classification of the (1+3) Dimensional Generalized Modified Schrödinger Equation Using Symmetry Reduction Approach"
+        },
+        {
+          "paperId": "6e86acd0f69ed4575cfbdc248ff102a11a737e78",
+          "title": "Investigation of New Optical Solutions for the Fractional Schrödinger Equation with Time-Dependent Coefficients: Polynomial, Random, Trigonometric, and Hyperbolic Functions"
+        },
+        {
+          "paperId": "11db1f71c02a95cd75eb7a5091de6f6d30642681",
+          "title": "Series Solution and Wave Solution of Time Fractional Generalized Korteweg-de Vries Equation"
+        },
+        {
+          "paperId": "7a9f58b71fd98a7d1a5e106808151de117ed63df",
+          "title": "Exploring soliton solutions of Zakharov–Kuznetsov dynamical model with applications"
+        },
+        {
+          "paperId": "6c789b49aee01fd72dec3e0d50c16e9889d370e7",
+          "title": "Comparison Between Two Methods to Find Exact Solutions for a New Models of Nonlinear Partial Differential Equations"
+        },
+        {
+          "paperId": "d43ba8864a8cba0e3a26d9b4cc874bf1481bac26",
+          "title": "Bifurcation analysis of small amplitude unidirectional waves for nonlinear Schrödinger equations with fractional derivatives"
+        },
+        {
+          "paperId": "b026e4e8d55d137c1c53b0f5917dd1b0be05220a",
+          "title": "Exact Solutions to New Potential Nonlinear Partial Differential Equations Using Extended Generalized Riccati Equation Mapping Method"
+        },
+        {
+          "paperId": "ec41a1dd8ec7f6deafa3a0aa4d09cefaab3c7eb2",
+          "title": "An Approximate Analytical View of Fractional Physical Models in the Frame of the Caputo Operator"
+        },
+        {
+          "paperId": "131a35569f3e00b96f2a4d92f834274ad63e2d1f",
+          "title": "Solitary Wave Solutions of the coupled Kawahara Equation"
+        },
+        {
+          "paperId": "dbe09e57dcd963607209c3eb18c8b6632fb68256",
+          "title": "Dynamic Characteristics of the Closed Soliton Solution and Phase Analysis of the (3+1)-Dimensional Jimbo-Miwa Equation"
+        },
+        {
+          "paperId": "2c716749139fa22296bb0344f128e28ce8c4c2c2",
+          "title": "Soliton solutions, sensitivity analysis, and multistability analysis for the modified complex Ginzburg-Landau model"
+        },
+        {
+          "paperId": "9caa55cd62f2e53085245b17d511580020a9cda6",
+          "title": "Traveling-wave solutions for a higher-order Boussineq system: existence and numerical analysis"
+        },
+        {
+          "paperId": "5c0be6bd70bd0201c396344ac6b30ca54a6509c5",
+          "title": "Application of modiﬁed extended direct algebraic method to nonlinear fractional diffusion reaction equation with cubic nonlinearity"
+        },
+        {
+          "paperId": "a49c5a21d3f8b65098005237e46575e94735c214",
+          "title": "Novel singular and non-singular complexiton, interaction wave and the complex multi-soliton solutions to the generalized nonlinear evolution equation"
+        },
+        {
+          "paperId": "474f83d14003754e47caf983f9c9ba7b4d45c210",
+          "title": "Existence and Asymptotic Behaviors of Traveling Wave Solutions for the FitzHugh–Nagumo System"
+        }
+      ]
+    },
+    {
+      "paperId": "6e0f4213a73e05cd8e10daef8c76bafcac30ce6b",
+      "title": "Numerical solution of two-term time-fractional PDE models arising in mathematical physics using local meshless method",
+      "recommendations": [
+        {
+          "paperId": "6174723b7b81797b8a8356e0fe65bc084b0eb1a8",
+          "title": "A High‐Precision Meshless Method for Time‐Fractional Mixed Diffusion and Wave Equations"
+        },
+        {
+          "paperId": "75bbbe885d0f15edc449ba5720ceba21ad3cc436",
+          "title": "Efficient Layer-Resolving Fitted Mesh Finite Difference Approach for Solving a System of n Two-Parameter Singularly Perturbed Convection–Diffusion Delay Differential Equations"
+        },
+        {
+          "paperId": "b82596b86dd8d4181ddc3b6b8aad85aa31cc5687",
+          "title": "Virtual element approximations of the time-fractional nonlinear convection-diffusion equation on polygonal meshes"
+        },
+        {
+          "paperId": "faa682c93feba100611e474911e2998f771b7918",
+          "title": "Advanced Fitted Mesh Finite Difference Strategies for Solving ‘n’ Two-Parameter Singularly Perturbed Convection–Diffusion System"
+        },
+        {
+          "paperId": "86e6e24bffbeb7cdcc2ef4f4201c53ea2d80dde7",
+          "title": "Solving one- and two-dimensional advection-diffusion type initial boundary value problems with a wavelet hybrid scheme"
+        },
+        {
+          "paperId": "2987c71751f9876ec5f323dba197f44d6414f289",
+          "title": "An Improved Numerical Scheme for 2D Nonlinear Time-Dependent Partial Integro-Differential Equations with Multi-Term Fractional Integral Items"
+        },
+        {
+          "paperId": "5f028b11186c3bf876a514693aa9c63d9770189b",
+          "title": "An asymptotic preserving scheme for the M1model of non-local thermal transport for two-dimensional structured and unstructured meshes"
+        },
+        {
+          "paperId": "2fab19025be7ae14de9387bc2577f7b67a3beacb",
+          "title": "An exponential integrator multicontinuum homogenization method for fractional diffusion problem with multiscale coefficients"
+        },
+        {
+          "paperId": "2877b9d1420b3b22f07c1de07cb5ef5bbb863e84",
+          "title": "A Second-order method on graded meshes for fractional Laplacian via Riesz fractional derivative with a singular source term"
+        },
+        {
+          "paperId": "7984d9b568eee98b60a838410a64750f86d0e76e",
+          "title": "Analytical solution of the systems of nonlinear fractional partial differential equations using conformable Laplace transform iterative method"
+        },
+        {
+          "paperId": "fd84d1e458a767cbd43ad6d13ed31206c22e732b",
+          "title": "A numerical approach to approximate the solution of a quasilinear singularly perturbed parabolic convection diffusion problem having a non-smooth source term"
+        },
+        {
+          "paperId": "a0bead408ce41530e78346dd66ca971b5a729e83",
+          "title": "Cubic non-polynomial spline on piecewise mesh for singularly perturbed reaction differential equations with robin type boundary conditions"
+        },
+        {
+          "paperId": "72bcf0b520fb0048c4ec4e1a35b87d861e9410a9",
+          "title": "Vectorised Parallel in Time methods for low-order discretizations with application to Porous Media problems"
+        },
+        {
+          "paperId": "8131402e7c265f5acf7b982905678656db1db86a",
+          "title": "A Novel Algorithm for Time Fractional Advection–Diffusion Equation"
+        },
+        {
+          "paperId": "51bd5154f38e7ddeefaf3ca285b712e6826d77c3",
+          "title": "First‐Order Empirical Interpolation Method for Real‐Time Solution of Parametric Time‐Dependent Nonlinear PDEs"
+        },
+        {
+          "paperId": "ec642b5e53235140dbd61891f1160c982c3c83a0",
+          "title": "A novel exponentially fitted finite-difference method for time-fractional singularly perturbed convection–diffusion problems with variable coefficients"
+        },
+        {
+          "paperId": "f4b1c6d4780d21a7299adb786173075e9ca68beb",
+          "title": "A Collocation-Based Framework for the Computational Solution of Mixed-Order Fractional Differential Equations"
+        },
+        {
+          "paperId": "2dd40e81c80e8a4479fdd28979e597bf07b8a96d",
+          "title": "A Fast Finite Difference Method for 2D Time Fractional Mobile/Immobile Equation with Weakly Singular Solution"
+        },
+        {
+          "paperId": "dc18db96b437127bc8410d95d53a69f23e9e23fd",
+          "title": "A nodally bound-preserving finite element method for time-dependent convection-diffusion equations"
+        },
+        {
+          "paperId": "e881911a84884d055b96305e91db20cb23f45bae",
+          "title": "A semi-adaptive finite difference method for simulating two-sided fractional convection-diffusion quenching problems"
+        }
+      ]
+    },
+    {
+      "paperId": "c601e5e9a9070c9cf57f0157f0fd1666dbf0c6b2",
+      "title": "Students’ attitude and motivation in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "573c6906b3f47b20cd62829bed26f7dce642ab1a",
+          "title": "The Image of the Mathematics Teachers in High School Students"
+        },
+        {
+          "paperId": "05e4847e0ae01771c6215046674cd968e1d78a69",
+          "title": "Investigating the effect of teaching kinematics concepts using thought experiments on students’ academic progress and learning strategies"
+        },
+        {
+          "paperId": "d4e0e92910193be164565305d01ddb3dd0439641",
+          "title": "Contribution of School Environment to Student Learning Motivation in Social"
+        },
+        {
+          "paperId": "d8ff229720877528dd27f65fc7889a0498de5113",
+          "title": "Science Laboratory Environment and Students’ Motivation as Predictors on Attitudes Towards Physics Lesson"
+        },
+        {
+          "paperId": "8cba0de837565a67a0fd9aac825f79edeaf5e58f",
+          "title": "Mathematics teachers’ beliefs about primary school students’ mathematical attitudes"
+        },
+        {
+          "paperId": "cd1a029db403aa7f841525d20541f0f136b62b39",
+          "title": "Relationship between Epistemological Beliefs and Students’ Academic Achievement in Mathematics"
+        },
+        {
+          "paperId": "e69cec153381eb792cb4960f7ef68a6ea9661d69",
+          "title": "Study on the Impact of Attitude, Motivation, and Study Time on Mathematics Performance in Secondary School Students"
+        },
+        {
+          "paperId": "9a514365cab773e50391a5dd25deb65510d5060f",
+          "title": "The Effect of Teaching on Entry Behavior of Students in Mathematics"
+        },
+        {
+          "paperId": "1d99bc2052df5ac03a7a3db02f4f383101f850f0",
+          "title": "Learning Barriers of the Grade 10 Students and Its Correlation to Their Conceptual Understanding in Mathematics"
+        },
+        {
+          "paperId": "3c64009cbc65eac4ce3f05228dabcfb305d19fbd",
+          "title": "Exploring Research Attitude in M.Ed. (Master of Education) Students: A Quantitative Study"
+        },
+        {
+          "paperId": "293299eb9038672d5486c43d35c5232628138a32",
+          "title": "Optimizing Mathematics Learning: The Role of Teaching Strategies and Student’s Interests in Performance"
+        },
+        {
+          "paperId": "1cd6db00faca962c0fb5a957f50ba2916728fb39",
+          "title": "Resolving Learners Differences in the Learning of Mathematics"
+        },
+        {
+          "paperId": "c34ea64012022a15afc6b2a2591af812d696a8b2",
+          "title": "SOME MEASURES TO CREATE LEARNING MOTIVATION FOR STUDENTS IN TEACHING THE CONTENT OF “INTEGERS” IN GRADE 6 MATHEMATICS"
+        },
+        {
+          "paperId": "7460bb7502adda632c818ebcdcaae1d2312e34bd",
+          "title": "Observing Mathematical Learning Experiences in the Primary Years to Examine How Attitudes Towards Mathematics Are Enacted in the Classroom"
+        },
+        {
+          "paperId": "ecfe1740dfaf0d4b5ba9cc0ca49237f36c18d43b",
+          "title": "Numeracy Skills and Attitude Towards Mathematics of Students in Relation to Performance: Basis for Intervention Program"
+        },
+        {
+          "paperId": "5ae22fe72b0249d0e7134e95f74b5e1383ec276c",
+          "title": "The Effectiveness of the Realistic Mathematics Education Approach to Improve Students' Creativity in Learning Mathematics"
+        },
+        {
+          "paperId": "89417f7d966ef5b4e757df0c79d5eaa53f6dd089",
+          "title": "The Myths of Mathematics That Never Fits To the Academics of Engineering Students"
+        },
+        {
+          "paperId": "0c02e1db0ff3990d5cda4bbf40c4aa50fd1c62c2",
+          "title": "The Impact of Experimental Problem-Solving in Technical Education on Students' Knowledge Acquisition"
+        },
+        {
+          "paperId": "85c2832320ea4f9e675c65b3b4ec00021f068599",
+          "title": "Untangling the “Why” of Math: Examining Student Perceptions on the Value of Mathematics in the Modern World"
+        },
+        {
+          "paperId": "0284565e22ee4ace01d97bcb3957626e241761f1",
+          "title": "Mathematical Literacy in Algebra Content: The Trajectory of Students Conceptual Cognitive Style"
+        }
+      ]
+    },
+    {
+      "paperId": "f622a0c2f05b37fdde0db597081a89e3487f6d87",
+      "title": "Communications in Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "30107975b89587cf8457d005730ddd8c44542e88",
+          "title": "MIT Open Access Articles The generalized Legendre transform and its applications to inverse spectral problems"
+        },
+        {
+          "paperId": "b51f7893d27694d764845df0087dd7eba48bfe35",
+          "title": "Random Modular Symbols"
+        },
+        {
+          "paperId": "8bc3ae18c0312e2646af6a7ab5db206539800fd0",
+          "title": "The characterization of differential operators"
+        },
+        {
+          "paperId": "36347692e384af5335e5f4793127382d4b3d8eb9",
+          "title": "Calculating Automorphism Groups and Monodromy for Classical Modular Curves"
+        },
+        {
+          "paperId": "e150fcaa2fcaa0842c627da97985fdff944cd430",
+          "title": "On the curvatures of curves in educlidean N-space"
+        },
+        {
+          "paperId": "7fbd2b18cac29f8a5a1316397270c01691e157fd",
+          "title": "and binomial coefficients"
+        },
+        {
+          "paperId": "615829bb4d5c8d8d0ba08cccdc59a8bd1e086b77",
+          "title": "The Laplace-Beltrami spectrum on Naturally Reductive Homogeneous Spaces"
+        },
+        {
+          "paperId": "7b7e484dfcf8b962944fc9fa49796dbcaded61b8",
+          "title": "Dynamical systems defined by polynomials with algebraic properties"
+        },
+        {
+          "paperId": "c7e299d5bed376c25009e3a031d9921f02132989",
+          "title": "KLPT²: Algebraic Pathfinding in Dimension Two and Applications"
+        },
+        {
+          "paperId": "12379e5fcee21a9aa25722f42ff808d4e6be2cf3",
+          "title": "Möbius Transformations in the Second Symmetric Product of ℂ"
+        },
+        {
+          "paperId": "54569f2ca24dc62c282f787e197237ce45d08813",
+          "title": "Theorems of convex subgroups of semifields and vector spaces over semifields"
+        },
+        {
+          "paperId": "7eb0e614e420a9dce38b97797fbf7524ea56a0e6",
+          "title": "METRICAL PROPERTIES OF FUNCTIONS OF CONSECUTIVE DIGITS IN L ¨UROTH SERIES"
+        },
+        {
+          "paperId": "fa8754b59354b67bfa3d384041dcb9080fa82c76",
+          "title": "A generalization of m-topology and U-topology on rings of measurable functions"
+        },
+        {
+          "paperId": "80e4bc18dfad4bf319e48ba4ea3a34837694de58",
+          "title": "The action of certain simple lie algebras on some of their modules"
+        },
+        {
+          "paperId": "faf7cef07a086a072a2add6868f36654711619db",
+          "title": "Universality of compositions involving Gram points"
+        },
+        {
+          "paperId": "6fd3e2f0ab666f8c9f807f38cd07081c852297a9",
+          "title": "Plebanski complex"
+        },
+        {
+          "paperId": "40c2363077b36789c698a7bba89ab268a25dc830",
+          "title": "Two dimensional versions of the affine Grassmannian and their geometric description"
+        },
+        {
+          "paperId": "6207eefbea0d6f7ac24692e1ef80e4633da63faa",
+          "title": "Homomorphisms of some hyperrings"
+        },
+        {
+          "paperId": "bb7b5a687aeaea76f0d51f31ce99ca6a38d9fa3f",
+          "title": "Characterization of stable manifolds of orbits with weak hyperbolicity and its application"
+        },
+        {
+          "paperId": "8251fb46410f8f0eec99a5ebce03856dfd1ae8cb",
+          "title": "Polylogarithms and Subordination of Some Cubic Polynomials"
+        }
+      ]
+    },
+    {
+      "paperId": "cf91760e9abbc88b67f4eca54b724fa4689709bb",
+      "title": "The improved F-expansion method with Riccati equation and its applications in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "6c789b49aee01fd72dec3e0d50c16e9889d370e7",
+          "title": "Comparison Between Two Methods to Find Exact Solutions for a New Models of Nonlinear Partial Differential Equations"
+        },
+        {
+          "paperId": "9062f81843c10b45c91cf3d57338866cfb1b9e86",
+          "title": "Prolongation Structure of a Development Equation and Its Darboux Transformation Solution"
+        },
+        {
+          "paperId": "f4fe7473e65b6a316f8c982e06711158306d7838",
+          "title": "The analysis of the traveling wave solutions of the Hirota-Ramani equation via the modified Kudryashov method"
+        },
+        {
+          "paperId": "04d05ada2bb17a851ed210ea3aff8b69ba930003",
+          "title": "Exact Solutions and Classification of the (1+3) Dimensional Generalized Modified Schrödinger Equation Using Symmetry Reduction Approach"
+        },
+        {
+          "paperId": "fa4caac4e0ba375e8a779d20c3d2ceeff93c18e2",
+          "title": "On the variational principles of the Burgers-Korteweg-de Vries equation in fluid mechanics"
+        },
+        {
+          "paperId": "4c1c46d0b50576d99ef723445f898cf69216b671",
+          "title": "Explicit and accurate solutions for the Benney equation"
+        },
+        {
+          "paperId": "a2ff6dcddc9138c58d6fd5a7559b472217ee98aa",
+          "title": "El-Zaki Transform Method for Solving Applications of Some Integral Differential Equations"
+        },
+        {
+          "paperId": "2f4358a57f352c6eca4c85e5947927e8698042ed",
+          "title": "COUPLING THE REDUCED DIFFERENTIAL TRANSFORMATION METHOD AND PICARD’S PRINCIPLE FOR SOLVING NONLINEAR EQUATIONS"
+        },
+        {
+          "paperId": "c172449496cf9f735adf73008c18e57dfafb9bd7",
+          "title": "Numerical solutions to the time-dependent Schrödinger equation for a model problem"
+        },
+        {
+          "paperId": "47e301c7a9ec9aaaee814ad68de7894bf8974e37",
+          "title": "New Analytical Wave Structures for the (2+1)-Dimensional Chaffee-Infante Equation"
+        },
+        {
+          "paperId": "ff7706a4e9e7dc963b8619eaf2457e90668e1474",
+          "title": "AN ADAPTED ANALYTICAL SOLUTION TO THE MULHOLLAND EQUATION: MODIFIED DIRECT ITERATION PROCEDURE"
+        },
+        {
+          "paperId": "7b325640cb5ed1fcd35ffa9a3cba6846c878d34b",
+          "title": "Bifurcations and exact solutions of generalized nonlinear Schrödinger equation"
+        },
+        {
+          "paperId": "46b524e9da014e97f8097e19158bbf7d9a287214",
+          "title": "Generalized variational principles of the Benjamin-Bona-Mahony-Peregrine-Burgers equation for nonlinear surface waves"
+        },
+        {
+          "paperId": "badae2a575933a2b7bc6298dc5378159d9f6ea18",
+          "title": "The renormalization method without spectrum theory for the perturbation of solitons"
+        },
+        {
+          "paperId": "a6aef3d75ccbef33ce2a23b56db4e31155d494f1",
+          "title": "Modification of Picard's Iterative Method for the Solution of Fractional Differential Equations"
+        },
+        {
+          "paperId": "131a35569f3e00b96f2a4d92f834274ad63e2d1f",
+          "title": "Solitary Wave Solutions of the coupled Kawahara Equation"
+        },
+        {
+          "paperId": "8bb58f26e96c18bd8e6c8775b49d1a6a8cfa7d21",
+          "title": "Exploring Fractional Damped Burgers’ Equation: A Comparative Analysis of Analytical Methods"
+        },
+        {
+          "paperId": "1f33ce22dc07345e6a78f24ca16a5c5601727fb9",
+          "title": "A note on the existence of self-similar profiles of the hydrodynamic formulation of the focusing nonlinear Schr\\\"odinger equation"
+        },
+        {
+          "paperId": "5c0be6bd70bd0201c396344ac6b30ca54a6509c5",
+          "title": "Application of modiﬁed extended direct algebraic method to nonlinear fractional diffusion reaction equation with cubic nonlinearity"
+        },
+        {
+          "paperId": "0eb6e7a726d7804b6b99439e5d7c30ce4520d932",
+          "title": "Evaluating Feynman Integrals through differential equations and series expansions"
+        }
+      ]
+    },
+    {
+      "paperId": "55bb62e4a82a26daaf2f6630a001e2b3f9f43407",
+      "title": "Open problems in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "b5a25ec6f80cb5534a21f34092105b352c0958b3",
+          "title": "The Great Rift in Physics"
+        },
+        {
+          "paperId": "1ec3e981b74214e8cadb824f068aa352791ab8c5",
+          "title": "Possibility in Physics"
+        },
+        {
+          "paperId": "14cb296626263c495dad9d80d43ed05fea612141",
+          "title": "Non-empirical physics from a historical perspective: New pathways in history and philosophy of physics."
+        },
+        {
+          "paperId": "3a0d83e9e9e159e42847fccdba006ed188436363",
+          "title": "Black Hole Physics: A Review of Theory, Observations, and Paradoxes"
+        },
+        {
+          "paperId": "93f2561bf97403f8f645a1b4f0e4301f51380f3c",
+          "title": "A simple and uniﬁed explanation of modern physics"
+        },
+        {
+          "paperId": "a9cf9a980daf4b1ef4a3260bd59b04b8acc942a0",
+          "title": "IS PHILOSOPHY NEEDED TO SOLUTION THE PROBLEMSOF MODERN PHYSICS? (RESPONDING TO STEPHEN HAWKING)"
+        },
+        {
+          "paperId": "c411696d0e2a4a25780fc7dd1068109f738ff1f3",
+          "title": "Physics and Complexity"
+        },
+        {
+          "paperId": "84ce2e2d04a186d3a015866c3748aef71ec93720",
+          "title": "QUANTUM MECHANICS FOR THE COMMON MAN"
+        },
+        {
+          "paperId": "0a42b700f5b6c9786e64922d429f113103553d66",
+          "title": "Copenhagen Survey on Black Holes and Fundamental Physics"
+        },
+        {
+          "paperId": "bd495ac1bf9d01b51f72bb75de85332bf5e81507",
+          "title": "A preliminary vocabulary of complexity"
+        },
+        {
+          "paperId": "bca60c5398b70b2cb07bb8dfc7a4da90a36c3864",
+          "title": "A thinking on Quantum Physics and common sense"
+        },
+        {
+          "paperId": "32531d62cc2c2caa8e3869d4932945e2e27c733e",
+          "title": "The rise of stochasticity in physics"
+        },
+        {
+          "paperId": "f0c20529063a80f6d8fdc249dd8ed7c0ed53e537",
+          "title": "Calculus of Variations"
+        },
+        {
+          "paperId": "4b102de697c3a4ac76af3192924454c96df4d379",
+          "title": "Why Do We Want a Theory of Quantum Gravity?"
+        },
+        {
+          "paperId": "f68e7e6ee209e579a3560b75152cafd886ad14bf",
+          "title": "A Comprehensive Review of Quantum Mechanics: Foundations, Principles, and Applications"
+        },
+        {
+          "paperId": "97839462c77f6838094d36ba230a2d95d876981e",
+          "title": "Reinterpreting the Riemann Hypothesis: A Theoretical Framework Bridging Mathematics and Universal Symmetry"
+        },
+        {
+          "paperId": "0632d39a96e76f15cf472190fc8acd29bb08ed70",
+          "title": "Is Time a fundamental Category? Suggesting Time as based on more fundamental Categories proposing a discrete Model on smallest Scales"
+        },
+        {
+          "paperId": "1518655672ee004e0d7f0732b843855641a85f43",
+          "title": "Is the information loss problem a paradox?"
+        },
+        {
+          "paperId": "55d699b431ee4c60b4d59f15e450f82c2c346753",
+          "title": "Two or three things particle physicists (mis)understand about (pre)heating"
+        },
+        {
+          "paperId": "895b57ecf7d84216b9b5129c4b34cfbc31b51630",
+          "title": "A brief introduction to fluctuation theorems: from theory to experiments"
+        }
+      ]
+    },
+    {
+      "paperId": "d1bf87a515b0fd410cfda10a308920d72b6d92ac",
+      "title": "The (G' G)-expansion method and travelling wave solutions of nonlinear evolution equations in mathematical physics",
+      "recommendations": [
+        {
+          "paperId": "47e301c7a9ec9aaaee814ad68de7894bf8974e37",
+          "title": "New Analytical Wave Structures for the (2+1)-Dimensional Chaffee-Infante Equation"
+        },
+        {
+          "paperId": "9caa55cd62f2e53085245b17d511580020a9cda6",
+          "title": "Traveling-wave solutions for a higher-order Boussineq system: existence and numerical analysis"
+        },
+        {
+          "paperId": "32b00467ed393593c279fa853cd85dc4f3876c5d",
+          "title": "Traveling-Wave Solutions of Several Nonlinear Mathematical Physics Equations"
+        },
+        {
+          "paperId": "f4fe7473e65b6a316f8c982e06711158306d7838",
+          "title": "The analysis of the traveling wave solutions of the Hirota-Ramani equation via the modified Kudryashov method"
+        },
+        {
+          "paperId": "2a132d807ae65d2001fb61890b2911550f358b2d",
+          "title": "Traveling Wave Structures of the (2+1)-Dimensional B-type Kadomtsev-Petviashvili Equation"
+        },
+        {
+          "paperId": "131a35569f3e00b96f2a4d92f834274ad63e2d1f",
+          "title": "Solitary Wave Solutions of the coupled Kawahara Equation"
+        },
+        {
+          "paperId": "5c0be6bd70bd0201c396344ac6b30ca54a6509c5",
+          "title": "Application of modiﬁed extended direct algebraic method to nonlinear fractional diffusion reaction equation with cubic nonlinearity"
+        },
+        {
+          "paperId": "6c789b49aee01fd72dec3e0d50c16e9889d370e7",
+          "title": "Comparison Between Two Methods to Find Exact Solutions for a New Models of Nonlinear Partial Differential Equations"
+        },
+        {
+          "paperId": "3e0fd8f17b84cfa11b5afc8c962d7d079eece59f",
+          "title": "On Some Novel Soliton Structures for the Beta-Time Fractional Benjamin–Ono Dynamical Equation in Fluids"
+        },
+        {
+          "paperId": "2524dea9e3706f5bb50932d386ed4dac38cce8c9",
+          "title": "Multiple Solutions and Dynamical Behavior of the Periodically Excited Beta-Fractional Generalized KdV-ZK System"
+        },
+        {
+          "paperId": "6e86acd0f69ed4575cfbdc248ff102a11a737e78",
+          "title": "Investigation of New Optical Solutions for the Fractional Schrödinger Equation with Time-Dependent Coefficients: Polynomial, Random, Trigonometric, and Hyperbolic Functions"
+        },
+        {
+          "paperId": "b026e4e8d55d137c1c53b0f5917dd1b0be05220a",
+          "title": "Exact Solutions to New Potential Nonlinear Partial Differential Equations Using Extended Generalized Riccati Equation Mapping Method"
+        },
+        {
+          "paperId": "05cfe18138aca2828eac74b850402ad433eeb996",
+          "title": "Two-component nonlinear wave solutions of the sixth-order generalised Boussinesq-type equations"
+        },
+        {
+          "paperId": "9754eee9f128eeedd6933fe901ba2d1ead80048b",
+          "title": "Exact Solution for Nonlinear Acoustics Model with Conformable Derivative"
+        },
+        {
+          "paperId": "474f83d14003754e47caf983f9c9ba7b4d45c210",
+          "title": "Existence and Asymptotic Behaviors of Traveling Wave Solutions for the FitzHugh–Nagumo System"
+        },
+        {
+          "paperId": "7b325640cb5ed1fcd35ffa9a3cba6846c878d34b",
+          "title": "Bifurcations and exact solutions of generalized nonlinear Schrödinger equation"
+        },
+        {
+          "paperId": "dbe09e57dcd963607209c3eb18c8b6632fb68256",
+          "title": "Dynamic Characteristics of the Closed Soliton Solution and Phase Analysis of the (3+1)-Dimensional Jimbo-Miwa Equation"
+        },
+        {
+          "paperId": "a726f831a6f1833b636e44f35e4573620e020bd4",
+          "title": "Exploring the wave’s structures to the nonlinear coupled system arising in surface geometry"
+        },
+        {
+          "paperId": "a49c5a21d3f8b65098005237e46575e94735c214",
+          "title": "Novel singular and non-singular complexiton, interaction wave and the complex multi-soliton solutions to the generalized nonlinear evolution equation"
+        },
+        {
+          "paperId": "1b559cdc0ec46a12a198981ed5807945366b4453",
+          "title": "Numerical Solution of Extended Korteweg-de Vries Equation with Cubic Nonlinear Term and Fifth-Order Dispersion Term"
+        }
+      ]
+    },
+    {
+      "paperId": "ead874367ad0d4bbb1bce3dbd2d124866b234fa2",
+      "title": "Communications in Mathematical Physics Elliptic Genera of 2 d N = 2 Gauge Theories",
+      "recommendations": [
+        {
+          "paperId": "8e160642c051d21c464c4ba080e488d6ab497869",
+          "title": "ANNALES DE L’INSTITUT FOURIER"
+        },
+        {
+          "paperId": "c5404d3f863acd5ab1112f8e2d6e100658198314",
+          "title": "H IGHERSTRUCTURES Holomorphic Poisson Field Theories"
+        },
+        {
+          "paperId": "bd24fc29e974f717fc8812fda016185ec8a03a90",
+          "title": "On Asymptotic safety in 4D gauge theory with additional dimension=4 operators"
+        },
+        {
+          "paperId": "fb3156003603bcb6e8a55261646edd2bde85a452",
+          "title": "On dimensions of (2+1)D abelian bosonic topological systems on unoriented manifolds"
+        },
+        {
+          "paperId": "7b1b38044e66fca38a7557d1561ad47e40e9aa49",
+          "title": "Renormalization Group flow in Schur quantization"
+        },
+        {
+          "paperId": "bcc5228a99835e87d17e98d6f55e5d32148c6f50",
+          "title": "Higher-order $p$-form asymptotic symmetries in $D = p + 2$"
+        },
+        {
+          "paperId": "4574f76bb4d9a0c778debcbe3ddc28648e4ee0ae",
+          "title": "Some Aspects of Gauged Supergravity"
+        },
+        {
+          "paperId": "014e3e8b7da4099a9ce49273ebd6ac586648bad4",
+          "title": "Wilson loops and spherical branes"
+        },
+        {
+          "paperId": "4464d55bc4ebdbe430c9f61fc8c1fbd5906f7e37",
+          "title": "Thermodynamics of integrable N=2 theories, squared"
+        },
+        {
+          "paperId": "90cdeb6deaa1885ab526b65e88844c1c1d49d332",
+          "title": "Poisson Vertex Algebras and Three-Dimensional Gauge Theory"
+        },
+        {
+          "paperId": "5ba55a93fc13e8294fdc7e7d069fa909ac12e51a",
+          "title": "Some Constructions on Quantum Principal Bundles"
+        },
+        {
+          "paperId": "34d43f84718d2c2c19fe7cd3624ad45f59f38add",
+          "title": "Holographic deformations of matrix models"
+        },
+        {
+          "paperId": "daf3ecde47c71cda4e0c65327d5172b1c250398f",
+          "title": "Symplectic Cuts and Open/Closed Strings II"
+        },
+        {
+          "paperId": "89248402e39d4230a97eb83762c44db06abc2879",
+          "title": "The heterotic $G_2$ moduli space metric"
+        },
+        {
+          "paperId": "65af46147d193c3bafcd0aeb4b8561065100369a",
+          "title": "How to uplift D = 3 maximal supergravities"
+        },
+        {
+          "paperId": "7157c425143071c2d369e1804f76c8d91220b13e",
+          "title": "Introduction of the G$_2$-Ricci Flow: Geometric Implications for Spontaneous Symmetry Breaking and Gauge Boson Masses"
+        },
+        {
+          "paperId": "a4133d169b3b0fe3cfe403684cbdfa9e90a11fce",
+          "title": "Q-operators for the Ruijsenaars model"
+        },
+        {
+          "paperId": "b4b5ac90967969b3dd05d3810b40e4acf78ad8d7",
+          "title": "Non-associative Algebras of Cubic Matrices and their Gauge Theories"
+        },
+        {
+          "paperId": "e5980388d2c19c67aadb3993621c5f3c7f133649",
+          "title": "Linearized Coxeter Higher-Spin Theories"
+        },
+        {
+          "paperId": "d33b78085c8ed13feb5c98c55f028184b118b63f",
+          "title": "One-loop amplitudes in gauge theories"
+        }
+      ]
+    },
+    {
+      "paperId": "1b8d95f2dff66cb05db7ff9f76b0d36cdcf63c1b",
+      "title": "Orthogonal Polynomials in Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "dbdbdca5a34609bb7941068d4129a5b00b9d50b9",
+          "title": "Program: Titles and Abstracts of Invited Addresses"
+        },
+        {
+          "paperId": "0d9a3a613e5bb837e29f1c3136bd1d01c0ccb254",
+          "title": "Graphical functions with spin"
+        },
+        {
+          "paperId": "e80932fe569f9255a57389f78970e36226fbe339",
+          "title": "On spaces of functions associated to the canonical commutation relation"
+        },
+        {
+          "paperId": "7c55e9107275d702f1280c7388569717a8828ae9",
+          "title": "Hamiltonian dynamics of classical spins"
+        },
+        {
+          "paperId": "645bf8cce7250577256824f835217b35ba2e2b2d",
+          "title": "Some Properties of Fundamental Formulation of Tricomplex Polynomials"
+        },
+        {
+          "paperId": "b4b5ac90967969b3dd05d3810b40e4acf78ad8d7",
+          "title": "Non-associative Algebras of Cubic Matrices and their Gauge Theories"
+        },
+        {
+          "paperId": "50aa9de488a76140a048083e192764fe31af2806",
+          "title": "On Simple Modules over the Quantum Matrix algebra at roots of unity"
+        },
+        {
+          "paperId": "634b6bd246dfd7c6ed44f20ce49783d3c9ff2127",
+          "title": "Remarks on the locality of generalized global symmetries"
+        },
+        {
+          "paperId": "9665508f96f5bf861528e9ff1c34a298c7b719a4",
+          "title": "Quantum inequalities and their applications"
+        },
+        {
+          "paperId": "7510be2b7fcd752a49cd91a547b31f3577088a51",
+          "title": "Perspectives on the pure spinor superﬁeld formalism"
+        },
+        {
+          "paperId": "0a7c459b397fa2a2d2ba2b08edc4d31bfdf6cb53",
+          "title": "Matrix symmetric and quasi-symmetric functions and noncommutative representation theory"
+        },
+        {
+          "paperId": "be6a879d4127c29b731a96747bd494974a2e4c6b",
+          "title": "The Mathematical Basis of Peter Woit’s Geometric Approach to the Standard Model: A Cliﬀord Algebra Perspective"
+        },
+        {
+          "paperId": "f9a862d7fd7571901e768f286e1577d2dae6db8a",
+          "title": "Twisted moments of characteristic polynomials of random matrices in the unitary group"
+        },
+        {
+          "paperId": "d2407e168d6da567086fa262b7053e96bedd3951",
+          "title": "ORTHOGONALITY OF SPIN q -WHITTAKER POLYNOMIALS"
+        },
+        {
+          "paperId": "bfe6ec3821c09f29b0aa3962f79e62a5a00ef3c0",
+          "title": "Topological Entropy of Regular Chaotic Quadratic Maps"
+        },
+        {
+          "paperId": "c065f8765bdb42e6fa7d41ebcf30c35f1c3bda1f",
+          "title": "Quantum Field Theory and Statistical Systems Non-Abelian elastic collisions, associated diﬀerence systems of equations and discrete analytic functions"
+        },
+        {
+          "paperId": "841df573da5c5d73651039702333c2617d105feb",
+          "title": "Special conformal transformations in electrodynamics: mathematical foundations"
+        },
+        {
+          "paperId": "134f10724b44d840eaae836132e87e05f95dacb4",
+          "title": "Advances in Applied Mathematics"
+        },
+        {
+          "paperId": "ba7e33c04f1b41a1c7111aae5714cc50a66b3e7e",
+          "title": "Algebraic and Spectral Analysis of a Novel Hermitian Spin Basis"
+        },
+        {
+          "paperId": "31ae9c0baa5479e8222106288efafd4be59b3f4e",
+          "title": "Orthogonal polynomials with complex densities and quantum minimal surfaces"
+        }
+      ]
+    }
+  ],
+  "commutative algebra": [
+    {
+      "paperId": "a78c4d8308ec99087ec817b7984aaadbbf2ab25d",
+      "title": "Commutative Algebra: with a View Toward Algebraic Geometry",
+      "recommendations": [
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        },
+        {
+          "paperId": "fa6a1fe0626b0c857f8000a029d4ac57ff461ae4",
+          "title": "Aspects of Condensed Mathematics -- From Abstract Nonsense to Ergodic Theory"
+        },
+        {
+          "paperId": "209589b6a1f4d3e0b5ab8310f0344e80aef53b65",
+          "title": "A Shape Lemma for Ideals of Differential Operators"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "6a11a252c1ba215126442f0dac7429b07fc398c4",
+          "title": "Algebraic normalisation"
+        },
+        {
+          "paperId": "33f06ef34f7c7ab3190bad78567dc4b6cfe5cdd4",
+          "title": "Poisson Structures on the Trivial Extensions of Hereditary Algebras of Dynkin Type An"
+        },
+        {
+          "paperId": "cbb662e9c53d7ef520f40823775f6ebdf6001ecf",
+          "title": "Structure of Algebras Satisfying an ω-Polynomial Identity of Degree Six"
+        },
+        {
+          "paperId": "c859eb5f1b0dba137b3ee91239d66db36e7dc9cb",
+          "title": "Generalized topological d-algebra"
+        },
+        {
+          "paperId": "c9cfcd1b1e81d0d2af2a39fc01435d4c4ff1e8cb",
+          "title": "A linear AFL for quaternion algebras"
+        },
+        {
+          "paperId": "27d96a06b6d478e0875526b9cf878e2012f75b32",
+          "title": "Brackets and Projective Geometry in Macaulay2"
+        },
+        {
+          "paperId": "e5c43a845be5d23e4aaa887973202a5838e3bfc3",
+          "title": "Some incarnations of Hamiltonian reduction in symplectic geometry and geometric representation theory"
+        },
+        {
+          "paperId": "90a4383ea36935a9a5e6069d3fd33dfb6660ce2c",
+          "title": "Isomorphisms of Birkhoff-James orthogonality on finite-dimensional $C^*$-algebra"
+        },
+        {
+          "paperId": "549d5d1354ae793f880c389ecf34fe74f7424d5d",
+          "title": "An analog of the Hille theorem for hypercomplex functions in a finite-dimensional commutative algebra"
+        },
+        {
+          "paperId": "52df259958516f62424f65899551122fd6b4680d",
+          "title": "Differential forms and invariants of complex manifolds"
+        },
+        {
+          "paperId": "4c99fad7a1d2b27b62fdb166a4f16ca04e973b28",
+          "title": "Ranks of tensors: geometry and applications"
+        },
+        {
+          "paperId": "122c673853396d206da0e0be7da31d483e3d0928",
+          "title": "On the Gorensteiness of string algebras"
+        },
+        {
+          "paperId": "dedabe60ea4635d8c92aec436aa9bbbc736cc368",
+          "title": "Elliptic Regularity and the Hodge Decomposition Theorem"
+        },
+        {
+          "paperId": "c5c477a88c82b1aa64ed0d925a375c8b9950986a",
+          "title": "Comptes Rendus Mathématique"
+        },
+        {
+          "paperId": "ea07270878a6c4f3205f49e184e9b4aad86c2380",
+          "title": "NOTES ON APPLICATIONS OF GROTHENDIECK’S INEQUALITY"
+        },
+        {
+          "paperId": "808c098bab14083236c83930ef1a0ba430a2471a",
+          "title": "Growth problems in diagram categories"
+        }
+      ]
+    },
+    {
+      "paperId": "c1e93692a09c773db1982a66c073682395ebe830",
+      "title": "Dirac Geometry I: Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "e678d86915e721bc1ba64557ec90b77209a01f7e",
+          "title": "On the emergence of an almost-commutative spectral triple from a geometric construction on a configuration space"
+        },
+        {
+          "paperId": "b45613565aabfde6dce5e736233546d76237f975",
+          "title": "Inverse Hamiltonian reduction in type A and generalized slices in the affine Grassmannian"
+        },
+        {
+          "paperId": "5ba55a93fc13e8294fdc7e7d069fa909ac12e51a",
+          "title": "Some Constructions on Quantum Principal Bundles"
+        },
+        {
+          "paperId": "f44128718dd9be180a5b0496934847f2728b44e5",
+          "title": "Dirac Operators on Orbifold Resolutions: Uniform Elliptic Theory"
+        },
+        {
+          "paperId": "a40f370af22a676bc127a008ca29839b88376489",
+          "title": "Quantization of Lie-Poisson algebra and Lie algebra solutions of mass-deformed type IIB matrix model"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "2f6fd3b34046e283c48b2aa6008ca16d4575fe7f",
+          "title": "Types of elements in non-commutative Poisson algebras and Dixmier Conjecture"
+        },
+        {
+          "paperId": "ee5a4c44d53443a18b25467a3001292e2c2843ea",
+          "title": "Non-commutative derived analytic moduli functors"
+        },
+        {
+          "paperId": "62522a7bbd16d7e00c1fb4d755cd3198d8f40dfa",
+          "title": "The non-abelian extension and Wells map of Leibniz conformal algebra"
+        },
+        {
+          "paperId": "735e7df5cedd31b9e6e232be3ca4da2c5a7e2edf",
+          "title": "Graded Hecke Algebras for the Symmetric Group in Positive Characteristic"
+        },
+        {
+          "paperId": "1fc57ae48feec3b36ee398d6717d17520c530c16",
+          "title": "Cubic Dirac Operators and Dirac Cohomology for Basic Classical Lie Superalgebras"
+        },
+        {
+          "paperId": "26183f4643f7cb21c5368704339771a797281bf6",
+          "title": "On the construction of polynomial Poisson algebras: a novel grading approach"
+        },
+        {
+          "paperId": "90cdeb6deaa1885ab526b65e88844c1c1d49d332",
+          "title": "Poisson Vertex Algebras and Three-Dimensional Gauge Theory"
+        },
+        {
+          "paperId": "ae6f34dea5defd18ed17132dd322b018cc557051",
+          "title": "Quantum K--theory of Grassmannians from a Yang-Baxter algebra"
+        },
+        {
+          "paperId": "5a6b1a0b4f09e556374cc548f7424cbf238c8ef0",
+          "title": "The Tropical Dirac Equation"
+        },
+        {
+          "paperId": "8f13a175bd60a8e66cbd558c90fae562c91b348d",
+          "title": "Polarization algebras and the geometry of commuting varieties"
+        },
+        {
+          "paperId": "5128734240cfd8898c6c879800dbc70f7c671ea7",
+          "title": "Curved spacetimes from quantum mechanics"
+        },
+        {
+          "paperId": "b76ce5cc6d272954be0e178447105db12bda1ce8",
+          "title": "ANNALES DE L’INSTITUT FOURIER"
+        },
+        {
+          "paperId": "11e9ffdcfacada82e7de0cf41c54115b26102551",
+          "title": "Star-products for Lie-algebraic noncommutative Minkowski space-times"
+        },
+        {
+          "paperId": "ac1c9282b1f5a437d5fb75e38c81269fe4d61615",
+          "title": "BGG Sequences - A Riemannian perspective"
+        }
+      ]
+    },
+    {
+      "paperId": "19bf4cc7bb782d3377302fa8692880e434551846",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "b356e50ca7c4d5ef5e1225e5e4fe0fd65dcbea39",
+          "title": "Symmetric 2-(35,17,8) designs with an automorphism of order 2"
+        }
+      ]
+    },
+    {
+      "paperId": "1a3c19d080a63e0b67890e32050ba832f9d596eb",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "18efcede4d787ee0a58906c918e20f3f7204b3ab",
+          "title": "CW-complexes and Hilbert vector of standard graded Artinian Gorenstein algebras"
+        },
+        {
+          "paperId": "c9cfcd1b1e81d0d2af2a39fc01435d4c4ff1e8cb",
+          "title": "A linear AFL for quaternion algebras"
+        },
+        {
+          "paperId": "e9239d3a7c11b58fa182801060e06c077225efd1",
+          "title": "The Commutativity Condition of the Ring"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "6ddd9b1f94854eaf1fc564331f4a5373f79d94ac",
+          "title": "Spectral Theory on Unital Commutative full Symmetric Krein C*-Algebras"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "3377521c54c5c151b9ad9ce2fa785ca02dc3c43a",
+          "title": "Cohomology of Restricted Twisted Heisenberg Lie Algebras"
+        },
+        {
+          "paperId": "90a4383ea36935a9a5e6069d3fd33dfb6660ce2c",
+          "title": "Isomorphisms of Birkhoff-James orthogonality on finite-dimensional $C^*$-algebra"
+        },
+        {
+          "paperId": "cbb662e9c53d7ef520f40823775f6ebdf6001ecf",
+          "title": "Structure of Algebras Satisfying an ω-Polynomial Identity of Degree Six"
+        },
+        {
+          "paperId": "a58faaa7ebed63ab68b1a867ef26d3e2bd9253b8",
+          "title": "Affineness on Noetherian graded rings, algebras and Hopf algebras"
+        },
+        {
+          "paperId": "0ef27c49970b29915511cf29eb558fb69df78f9d",
+          "title": "SHEAF COHOMOLOGY GROUPS"
+        },
+        {
+          "paperId": "5894b87d383523387d39fa6fbe8113c78e631956",
+          "title": "Tensor Products of Quiver Bundles"
+        },
+        {
+          "paperId": "273c1e7a0fb7fa80b8c263d7c9d1d7473a9e2d76",
+          "title": "Koszul resolution for linear monoidal functors"
+        },
+        {
+          "paperId": "a490100e26127b86f51d5867bf44d680f6d35bfc",
+          "title": "A note on weight filtrations at the characteristic"
+        },
+        {
+          "paperId": "33f06ef34f7c7ab3190bad78567dc4b6cfe5cdd4",
+          "title": "Poisson Structures on the Trivial Extensions of Hereditary Algebras of Dynkin Type An"
+        },
+        {
+          "paperId": "60202db853b0f8a3510e5ca8fa3b860bf1cec2a1",
+          "title": "Comparing cohomology via exact split pairs in diagram algebras"
+        },
+        {
+          "paperId": "f7700a09da6992b46689a510f3b00e1592d9aa30",
+          "title": "Higher-dimensional module factorizations and complete intersections"
+        },
+        {
+          "paperId": "f0151a1d968027f7197293c6f8f01d975781d105",
+          "title": "Quasi-Boolean groups"
+        },
+        {
+          "paperId": "f1e3cd37664cf2e6aa5fc32806b9f196ae020349",
+          "title": "Finite symmetric algebras in tensor categories and Verlinde categories of algebraic groups"
+        },
+        {
+          "paperId": "525bcc425097a57bc9544526bcd51d72bebef1b7",
+          "title": "Algebraic Geometry: Wall Crossing and Moduli Spaces, Varieties and Derived Categories"
+        }
+      ]
+    },
+    {
+      "paperId": "b429880e0f19a287da1a9e39aef8dd8e908063ee",
+      "title": "Bernstein-Sato Polynomials in Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "209589b6a1f4d3e0b5ab8310f0344e80aef53b65",
+          "title": "A Shape Lemma for Ideals of Differential Operators"
+        },
+        {
+          "paperId": "fea924112c05b1673bf32f72189da7af7bd97c48",
+          "title": "A note on partial polynomial functions, in memory of Marek Jarnicki"
+        },
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        },
+        {
+          "paperId": "48aa8bcca1edba3093d011251b19d9bf177ef633",
+          "title": "A Nakano carrier type-theorem for orthogonally additive polynomials in Riesz spaces"
+        },
+        {
+          "paperId": "ac7062feff58882e0fbabb87c860e2c6ccde7781",
+          "title": "Jordan property for automorphism groups of compact varieties"
+        },
+        {
+          "paperId": "549d5d1354ae793f880c389ecf34fe74f7424d5d",
+          "title": "An analog of the Hille theorem for hypercomplex functions in a finite-dimensional commutative algebra"
+        },
+        {
+          "paperId": "7e4f4f53b73bcea16c742d9e5327fa984295b003",
+          "title": "A note on the approximation of divisor functions"
+        },
+        {
+          "paperId": "185b835998f53a8d7a746fef64905cef39af7afc",
+          "title": "An explicit proof of the generalized Gauss-Bonnet formula"
+        },
+        {
+          "paperId": "f44451f691e166d223bfa287ed06afb5e230f921",
+          "title": "FACTORIZATION IN THE RING OF ARITHMETIC FUNCTIONS ON GAUSSIAN INTEGERS"
+        },
+        {
+          "paperId": "ba5b621e7d80d092e4367ffdb0bd059165e92915",
+          "title": "Discrete Fourier Transform and $L$-functions"
+        },
+        {
+          "paperId": "7e2ce9175bfe6bf0491b5a3240c519dfc5df7a23",
+          "title": "A generalization of the harmonic series"
+        },
+        {
+          "paperId": "8f395259035c4feff67045c8ec7ef76bccdb5a86",
+          "title": "Hochschild cohomology for finitary 2-representations"
+        },
+        {
+          "paperId": "804c45d3fd80b810d89c8813ed5e427c69137aac",
+          "title": "A note on series of hyperbolic functions"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "2454dcbf7ff24a6767c750729e8bc32df0aa58eb",
+          "title": "Polynomial Continued Fractions for Algebraic Numbers"
+        },
+        {
+          "paperId": "b149f72fee40bd542e8f7ff703ca9c804eb0a48a",
+          "title": "Estimates for multiplicative functions, I."
+        },
+        {
+          "paperId": "6a11a252c1ba215126442f0dac7429b07fc398c4",
+          "title": "Algebraic normalisation"
+        },
+        {
+          "paperId": "1da820a4b78dcee7effa12aff4a6d8b56344a417",
+          "title": "Nice q-analogs of orthogonal polynomials with nice moments: Some simple examples"
+        },
+        {
+          "paperId": "8a0ff145d9705b805ed37376f1003ace06726bb6",
+          "title": "On some properties of Hopf manifolds"
+        },
+        {
+          "paperId": "f98aebe9c8e4405b7a7ac72a2f231b35c3d086f7",
+          "title": "Dynamical Mordell-Lang problem for automorphisms of surfaces in positive characteristic"
+        }
+      ]
+    },
+    {
+      "paperId": "539548881c0a6fd1f490a3155fcb58a060f105e5",
+      "title": "The partition complex: an invitation to combinatorial commutative algebra",
+      "recommendations": [
+        {
+          "paperId": "9361a9563be817140c75494fe749f7e349ece705",
+          "title": "Topologies on abelian groups and a topological five-lemma"
+        },
+        {
+          "paperId": "134f10724b44d840eaae836132e87e05f95dacb4",
+          "title": "Advances in Applied Mathematics"
+        },
+        {
+          "paperId": "dcb82fc1024eb02dc390262030a372bb09b6df65",
+          "title": "Fragmentation and Simplicity in Groups"
+        },
+        {
+          "paperId": "b15a88b91a61d873fd848eb3463310fcb96b5aa4",
+          "title": "Topology and its Applications"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "b76ce5cc6d272954be0e178447105db12bda1ce8",
+          "title": "ANNALES DE L’INSTITUT FOURIER"
+        },
+        {
+          "paperId": "77e801de581a29f7f50268f110c1322c4fea2f6f",
+          "title": "Mutation and the Gabriel spectrum"
+        },
+        {
+          "paperId": "8d0d7f684c19f597ddf51c8a25b26b8ab674ee5f",
+          "title": "Polarizations on a triangulated category"
+        },
+        {
+          "paperId": "0e0266fc020e4422c17a5d6a555a537794c0d0f2",
+          "title": "Harmonic covers of skeleta"
+        },
+        {
+          "paperId": "0b65e133e9f5171096275ca93d79965b0ff0d358",
+          "title": "SOME RESULTS ON THE TOPOLOGY OF ALGEBRAIC SURFACES"
+        },
+        {
+          "paperId": "400b001f52b0226ea22d454c254220dad02843ac",
+          "title": "Homological Integrals for Weak Hopf Algebras"
+        },
+        {
+          "paperId": "7510be2b7fcd752a49cd91a547b31f3577088a51",
+          "title": "Perspectives on the pure spinor superﬁeld formalism"
+        },
+        {
+          "paperId": "2bb2f0a517e272ae65f08755e18b8511a25127c4",
+          "title": "A general framework for quasi-isometries in symbolic dynamics beyond groups"
+        },
+        {
+          "paperId": "ec7065327adb76f0b9718126a24d6dd023059bed",
+          "title": "A multiplication formula for cluster characters in gentle algebras"
+        },
+        {
+          "paperId": "0a7c459b397fa2a2d2ba2b08edc4d31bfdf6cb53",
+          "title": "Matrix symmetric and quasi-symmetric functions and noncommutative representation theory"
+        },
+        {
+          "paperId": "30bb55f8101bdfdc2082bd51fb55989cd089172e",
+          "title": "Closure operations induced via resolutions of singularities in characteristic zero"
+        },
+        {
+          "paperId": "c2e0a9008fcc38ddd362630c382651d694de1e44",
+          "title": "Holomorphic automorphisms of Markov-type surfaces"
+        },
+        {
+          "paperId": "b45613565aabfde6dce5e736233546d76237f975",
+          "title": "Inverse Hamiltonian reduction in type A and generalized slices in the affine Grassmannian"
+        },
+        {
+          "paperId": "47c6762a6a556aef3c8c09f5bc8ea0d4e9255eb3",
+          "title": "Almost mathematics, Persistence module, and Tamarkin category"
+        },
+        {
+          "paperId": "0780a38afc8e5d976419c64c7b09b81123203e62",
+          "title": "Intrinsic Donaldson-Thomas theory. II. Stability measures and invariants"
+        }
+      ]
+    },
+    {
+      "paperId": "fdf8a672bb488ae729804c6cb998ef590b496144",
+      "title": "The spectrum of a twisted commutative algebra",
+      "recommendations": [
+        {
+          "paperId": "872e70ee0a72c14b00b7829c8eff63e61f5a9980",
+          "title": "The elliptic Hall algebra and the double Dyck path algebra"
+        },
+        {
+          "paperId": "47896e7e833f8e8ca2b8b986f5d84b854b7c3d7e",
+          "title": "Tensor invariants of finite and classical groups"
+        },
+        {
+          "paperId": "f0731ee04e95631e5f2ae7f54d7b6fcc673e3e35",
+          "title": "On the center of the generic affine Hecke algebra"
+        },
+        {
+          "paperId": "64e8df7a89d1903745cbc8721a96dea2cd6dba35",
+          "title": "Dirac operators twisted by ramified Euclidean line bundles"
+        },
+        {
+          "paperId": "2963af1699188648bde0388b868c1f3545d50e52",
+          "title": "On conservative algebras of 2-dimensional Algebras"
+        },
+        {
+          "paperId": "77aafe919106167209b0dfe55197bf2ed5224151",
+          "title": "Valuative compactifications of analytic varieties"
+        },
+        {
+          "paperId": "9de78c82f9e5a0739bad3d000d5f28f7925cdd35",
+          "title": "Twisted Verlinde Formula for Vertex Operator Algebras: The Prime Case"
+        },
+        {
+          "paperId": "00dd338f1fa94f2957a1a7238bc624f2fcff5eed",
+          "title": "Norms in equivariant homotopy theory"
+        },
+        {
+          "paperId": "26183f4643f7cb21c5368704339771a797281bf6",
+          "title": "On the construction of polynomial Poisson algebras: a novel grading approach"
+        },
+        {
+          "paperId": "aac5c96b2711c7a1e9d7bb52473c8074ec7b872d",
+          "title": "Constructing Chayet-Garibaldi algebras from affine vertex algebras (including the 3876-dimensional algebra for $E_8$)"
+        },
+        {
+          "paperId": "dee7e83c430506f67252a7bb455ca0ba5ba7810b",
+          "title": "Generalized Derivations of ω-Lie Algebras"
+        },
+        {
+          "paperId": "2519ddb14a3de784bb280b0e8a82b62032bb9701",
+          "title": "The tensor product of Whittaker modules for semisimple Lie algebras"
+        },
+        {
+          "paperId": "42aaf21383066449250fca8d99127c4227b583d2",
+          "title": "Polynomial invariants for two-dimensional algebras"
+        },
+        {
+          "paperId": "36a844a3bc9ab8b880ca309849a490b11c23b073",
+          "title": "On the finiteness of maps into simple abelian varieties satisfying certain tangency conditions"
+        },
+        {
+          "paperId": "8f13a175bd60a8e66cbd558c90fae562c91b348d",
+          "title": "Polarization algebras and the geometry of commuting varieties"
+        },
+        {
+          "paperId": "2e3a448cbb01ad51e513de2997e4cfca50f98ce8",
+          "title": "Clifford Multiplication on Spinor Abelian Varieties"
+        },
+        {
+          "paperId": "081edf19ecf472baed2b4d29d8fdb254fa5e6f25",
+          "title": "On the homology of special unitary groups over polynomial rings"
+        },
+        {
+          "paperId": "2eed2b8326b00fd3e1e043ddf523028b97c01ef2",
+          "title": "Elliptic loop spaces"
+        },
+        {
+          "paperId": "1d70356f9317bfe5eaa06fda64d8a9e2926ee189",
+          "title": "On the variety of Lie algebras endowed with complex structures: degenerations and deformations"
+        },
+        {
+          "paperId": "b7e48b048b555c081425d17ff3f9f9ce4a3f8334",
+          "title": "About an isomorphism between the Beurling algebra with a weight dependent convolution and the $L^1(G)$ group algebra"
+        }
+      ]
+    },
+    {
+      "paperId": "fd94a9c004d8aa4834aa9ade5002e2f826d1a6f9",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "c1985b2d8699da3288b6a54adaeeeb4a2de3247f",
+          "title": "Left Jacobson Rings"
+        },
+        {
+          "paperId": "ab274d4a4d0986754a68cd91fd70157c9b1efb8b",
+          "title": "Gorenstein Modules Induced by Foxby Equivalence"
+        },
+        {
+          "paperId": "5553bbacd548e4d6e14c99c077db46f3e00ea876",
+          "title": "Injectivity in some categories of semimodules over semirings"
+        },
+        {
+          "paperId": "7530ad36392db7dc9f70055070508ac3184c325a",
+          "title": "On Some Linear Mappings of Incidence Coalgebras"
+        },
+        {
+          "paperId": "744765e272a718d7ec298253f17d006afbedeb0c",
+          "title": "Characterization of ideals of Q-algebras related to its G-part"
+        },
+        {
+          "paperId": "0507ba3927dfad9fd826f7e5d52c1c655a64f01c",
+          "title": "Central polynomials for Z 2 -graded algebras and for algebras with involution"
+        },
+        {
+          "paperId": "336881fdffdfeb088b87d46cc942d60b255e6a25",
+          "title": "Admissible Semimorphisms of icl-Groupoids"
+        },
+        {
+          "paperId": "20c2d3d8041a64d3a0a17049ed0bd1a0288a80a7",
+          "title": "Galois extensions and Hopf-Galois structures"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "5b0fd6af26036ecd30a56026e3075431832e954c",
+          "title": "Weakly 2-quasi-prime sub-modules"
+        },
+        {
+          "paperId": "7fbd2b18cac29f8a5a1316397270c01691e157fd",
+          "title": "and binomial coefficients"
+        },
+        {
+          "paperId": "77e801de581a29f7f50268f110c1322c4fea2f6f",
+          "title": "Mutation and the Gabriel spectrum"
+        },
+        {
+          "paperId": "1400a4f90a552a4c8c9ed9498d28959b221206f4",
+          "title": "Homological dimensions under Foxby equivalence"
+        },
+        {
+          "paperId": "c42eb3935c8b4c68f874a68bf591baf5bdbe461f",
+          "title": "Commutative Algebras with One-Dimensional Square"
+        },
+        {
+          "paperId": "a34d0b16e59f56d401762e0371641e7c01475bcc",
+          "title": "Annihilation of cohomology and (strong) generation of singularity categories"
+        },
+        {
+          "paperId": "55bf518c326c06b0d465768a928cf2a432f03c9f",
+          "title": "E(n)-coactions on semisimple Clifford algebras"
+        },
+        {
+          "paperId": "76745d3abaf29f25b63d1663095709c653be5b39",
+          "title": "A CONJECTURE OF GROSS AND ZAGIER: CASE E ( Q ) tor ∼ = Z / 2 Z OR Z / 4 Z"
+        },
+        {
+          "paperId": "d0866df889d6196aed4e3eb290eaa719826beba0",
+          "title": "S-NOETHERIAN RINGS, MODULES AND THEIR GENERALIZATIONS"
+        },
+        {
+          "paperId": "1c8f72a385a6043009170ebc039f31d64adf70b9",
+          "title": "GRADED PSEUDO-VALUATION RINGS"
+        },
+        {
+          "paperId": "1167ba7a8b4c300c00620cdfc408f06336f8107d",
+          "title": "Cubic permutation polynomials and elliptic curves"
+        }
+      ]
+    },
+    {
+      "paperId": "4ec0c9fcace40ebb6fb96dd07b30f9b60744187d",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "ac5982d423aea39c1482d5320a3676760cd31e77",
+          "title": "Divisible commutative semigroups"
+        },
+        {
+          "paperId": "ce0070ee64643f6e013ac61b08a3308e24000981",
+          "title": "Generalized seminear-fields"
+        },
+        {
+          "paperId": "239de54fa011517a148cbcc4959d9640f4b0c60c",
+          "title": "Generalized di ﬀ erential identities on prime rings and algebras"
+        },
+        {
+          "paperId": "943d3edf4369523a7c8899d2a9b45228020b0d7e",
+          "title": "Characterization of Monotone Sequences of Positive Numbers Prescribed by Means"
+        },
+        {
+          "paperId": "8d8face1e222173e37fb1a2fd05ce076f6dd02a1",
+          "title": "Supremum subsequence entropy for IP-sets"
+        },
+        {
+          "paperId": "e9c6bf40f71c538dbb2deac71c97f7e250dbac9e",
+          "title": "Generalized semifields"
+        },
+        {
+          "paperId": "c301d3e6f276f71cf32b58ddcd9f5b896716a04f",
+          "title": "Comptes Rendus Mathématique"
+        },
+        {
+          "paperId": "0e6c713ca363c13dcf7de072fd06bf0c06ee42a6",
+          "title": "Topological vector space over the quaternions"
+        },
+        {
+          "paperId": "09137876951f0af1535796a24b6774e699d4f903",
+          "title": "On the Sum of Divisors function of linearly recurrent sequences"
+        },
+        {
+          "paperId": "afe863cb7a867b7455a2eebd8e26f4bd47d4fa10",
+          "title": "Central limit theorems of sums of powers of function of independent random variables"
+        },
+        {
+          "paperId": "59646d882c12341ae21f6dbfad6564adfdd50516",
+          "title": "Outcome for the Case (11,10; 1) Outcome for the Case (11,10; 1)"
+        },
+        {
+          "paperId": "d7ef63f1218bdb9dac80f464714979133c1e8bac",
+          "title": "On lifting of embeddings between transitive models of set theory"
+        },
+        {
+          "paperId": "e398e9f95778a8193bcb8c5a2e2e1c44e3836913",
+          "title": "Second-Level Numerical Semigroups"
+        },
+        {
+          "paperId": "93f5cac0f03a8f774a42b785b52dfdbc0369de48",
+          "title": "On the Structure of σ_(1 )Near - Rings"
+        },
+        {
+          "paperId": "54569f2ca24dc62c282f787e197237ce45d08813",
+          "title": "Theorems of convex subgroups of semifields and vector spaces over semifields"
+        },
+        {
+          "paperId": "de671a0dfada0d98ebf38c2b049c1853f559a042",
+          "title": "Generalized transformation semigroups having proper dense subsemigroups"
+        },
+        {
+          "paperId": "7b7e484dfcf8b962944fc9fa49796dbcaded61b8",
+          "title": "Dynamical systems defined by polynomials with algebraic properties"
+        },
+        {
+          "paperId": "b51f7893d27694d764845df0087dd7eba48bfe35",
+          "title": "Random Modular Symbols"
+        },
+        {
+          "paperId": "8340501770b3b3f1edcd044fa0da5a3ee43f679b",
+          "title": "Abelian objects in categories with normal projections"
+        },
+        {
+          "paperId": "7ca3deab996cca0a9595855b3fad4ad57c0f7242",
+          "title": "Numerical radius peak multilinear mappings on ℓ1"
+        }
+      ]
+    },
+    {
+      "paperId": "35a2f7ce36a13429992ebd43393794e03c46e466",
+      "title": "Generalizations of Stillman’s Conjecture via Twisted Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "30acfa1edac5810e5af085d4d078aa536a75f480",
+          "title": "A reduction theorem for non-vanishing of Hochschild cohomology of block algebras and Happel's property"
+        },
+        {
+          "paperId": "52b50fb0fe1d68be5f7f6f57589c34739592dd7d",
+          "title": "Logarithmic Tate conjectures over finite fields"
+        },
+        {
+          "paperId": "c9cfcd1b1e81d0d2af2a39fc01435d4c4ff1e8cb",
+          "title": "A linear AFL for quaternion algebras"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "6b63dbe24993dd476d43895e55808837b3a1a086",
+          "title": "A higher algebraic approach to liftings of modules over derived quotients"
+        },
+        {
+          "paperId": "7f7208f0a80256622c9396ef376604b17569e293",
+          "title": "Curves of best approximation on wonderful varieties"
+        },
+        {
+          "paperId": "3377521c54c5c151b9ad9ce2fa785ca02dc3c43a",
+          "title": "Cohomology of Restricted Twisted Heisenberg Lie Algebras"
+        },
+        {
+          "paperId": "8906e052f709ffffdf36569a3621338a119c5fcb",
+          "title": "A proof of generic Green's conjecture in odd genus"
+        },
+        {
+          "paperId": "92e046b9e1240f44c08a9a5056be7253a4fc0c20",
+          "title": "ON THE ARITHMETICAL SURJECTIVITY CONJECTURE\nOF COLLIOT-THELENE"
+        },
+        {
+          "paperId": "134f10724b44d840eaae836132e87e05f95dacb4",
+          "title": "Advances in Applied Mathematics"
+        },
+        {
+          "paperId": "a58faaa7ebed63ab68b1a867ef26d3e2bd9253b8",
+          "title": "Affineness on Noetherian graded rings, algebras and Hopf algebras"
+        },
+        {
+          "paperId": "400b001f52b0226ea22d454c254220dad02843ac",
+          "title": "Homological Integrals for Weak Hopf Algebras"
+        },
+        {
+          "paperId": "c343e24ba31f4a291378c952a243a7e0f016bc9b",
+          "title": "Unitary Friedberg-Jacquet periods and their twists: Fundamental lemmas"
+        },
+        {
+          "paperId": "d6ed1dc84a8ef66e194e76eb44782faf41e61863",
+          "title": "A noncommutative generalization of Hunter's positivity theorem"
+        },
+        {
+          "paperId": "0b5ee362b8460c6e9bf2707461b4bfe6767990e7",
+          "title": "On the topology of real algebraic stacks"
+        },
+        {
+          "paperId": "275eb71cd14d327022870f5d4ec17382332e6d8a",
+          "title": "Counter-example to a Strong Matroid Minor Conjecture"
+        },
+        {
+          "paperId": "1bcb1b622658e70c0d65514b56f498e4cbb516bb",
+          "title": "Groups with exotic finiteness properties from complex Morse theory"
+        },
+        {
+          "paperId": "d7b6c70d6c740e36549e474ceaf5c43964b3d660",
+          "title": "Unitary Friedberg-Jacquet periods and their twists: Relative trace formulas"
+        },
+        {
+          "paperId": "b9d97363ff952fb352520effd3d09f2cb0de8716",
+          "title": "Jordan-Holder Theorem for profinite groups and applications"
+        },
+        {
+          "paperId": "4a9ea654b5dbf0d9ef6b026d27a8a7a873de63fd",
+          "title": "Beilinson's conjecture on K3 surfaces with an involution"
+        }
+      ]
+    },
+    {
+      "paperId": "85a483a03c110c5318ea7dfc0dae2778db40d256",
+      "title": "An algorithmic approach to the existence of ideal objects in commutative algebra",
+      "recommendations": [
+        {
+          "paperId": "cfba480702037bd05ee9a062ae89887795fff3d0",
+          "title": "The commutativity problem for effective varieties of formal series, and applications"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "b3dc3820c2fc90075645d7148587a9c7f44a89e6",
+          "title": "Fundamental algebraic sets and locally unit-additive rings"
+        },
+        {
+          "paperId": "ea6873894b7745ca25b07ab1eb853e5b270e8472",
+          "title": "Topological Kleene Field Theories: A new model of computation"
+        },
+        {
+          "paperId": "2bb2f0a517e272ae65f08755e18b8511a25127c4",
+          "title": "A general framework for quasi-isometries in symbolic dynamics beyond groups"
+        },
+        {
+          "paperId": "f37427a793c29ad3739ddfa1d9a207f53ce95f51",
+          "title": "A Survey on Lawvere's Fixed-Point Theorem"
+        },
+        {
+          "paperId": "77e801de581a29f7f50268f110c1322c4fea2f6f",
+          "title": "Mutation and the Gabriel spectrum"
+        },
+        {
+          "paperId": "ba1a3495828efb4d56ceeb315f349902f8bb85a5",
+          "title": "Establishing the Fundamental Theorem of Arithmetic"
+        },
+        {
+          "paperId": "8b45eebb971536541cfd9b8ea9b80d639dcf2ff8",
+          "title": "Extensions from within"
+        },
+        {
+          "paperId": "0b0ebeb1185910d78c0612cf9e91d3c455240b4f",
+          "title": "Day algebras"
+        },
+        {
+          "paperId": "41352cc1fa95c4885293ab5cae86118791021dca",
+          "title": "Hyperbolic Banach spaces I -- Directed completion of partial orders"
+        },
+        {
+          "paperId": "1e65d8c6108ab5d75a8395ca0330180444c4f111",
+          "title": "The incompleteness theorems and Berry’s paradox"
+        },
+        {
+          "paperId": "013307db3bfbe67aa471d861362744820e629485",
+          "title": "On extensivity of morphisms"
+        },
+        {
+          "paperId": "b44003d7257166e8bab009e9013686d91dd4ff88",
+          "title": "A Natural Transformation between the Model Constructions of the Completeness and Compactness Theorems, Enhanced by Rigidity and 2-Categorical Strengthening"
+        },
+        {
+          "paperId": "403dcde600bd144253f4add1608794d8ac247f94",
+          "title": "On the structure and theory of McCarthy algebras"
+        },
+        {
+          "paperId": "3144ec0bad392e1446a007d26894be5e0bbabd4c",
+          "title": "Uniform Monad Presentations and Graph Quasitoposes"
+        },
+        {
+          "paperId": "e680fa579c6845cb846fe8db84248f1f0115121b",
+          "title": "Multiplicities and degree functions in local rings via intersection products"
+        },
+        {
+          "paperId": "cac2eb8cceab8ed83e2604c0706205e39daeda37",
+          "title": "Conjunctive Concept Algebras"
+        },
+        {
+          "paperId": "9361a9563be817140c75494fe749f7e349ece705",
+          "title": "Topologies on abelian groups and a topological five-lemma"
+        },
+        {
+          "paperId": "b45613565aabfde6dce5e736233546d76237f975",
+          "title": "Inverse Hamiltonian reduction in type A and generalized slices in the affine Grassmannian"
+        }
+      ]
+    },
+    {
+      "paperId": "2a26808793cd335b9550ec063c00f527d4afab3e",
+      "title": "Topics on Smooth Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "081edf19ecf472baed2b4d29d8fdb254fa5e6f25",
+          "title": "On the homology of special unitary groups over polynomial rings"
+        },
+        {
+          "paperId": "2963af1699188648bde0388b868c1f3545d50e52",
+          "title": "On conservative algebras of 2-dimensional Algebras"
+        },
+        {
+          "paperId": "e12180c86190e9ffbbeaeda240da23a53fb37d9f",
+          "title": "Analytic Versus Algebraic Density of Polynomials"
+        },
+        {
+          "paperId": "2f05681b585d61fc6f75e16d85c2ccb27fccca52",
+          "title": "Free products and rescalings involving non-separable abelian von Neumann algebras"
+        },
+        {
+          "paperId": "699f6a05007aa7ba9def254430dfffdf58c3fdb1",
+          "title": "Equilevel algebras"
+        },
+        {
+          "paperId": "66760c6df8a29c099746bfb6c321d446d68ec0ad",
+          "title": "Notes on a special order on $\\mathbb{Z}^\\infty$"
+        },
+        {
+          "paperId": "f4402c6d7a27ab324b174dffb8c466fc17fe85ed",
+          "title": "The plus construction with respect to subrings of the rationals"
+        },
+        {
+          "paperId": "5f51407179b56975ec2675b97a2b507cdb5e0c25",
+          "title": "Morse theory of loop spaces and Hecke algebras"
+        },
+        {
+          "paperId": "3e1b7918da29cf90e57364bb7e6eb5afa22776d1",
+          "title": "Coordinate rings of regular nilpotent Hessenberg varieties in the open opposite schubert cell"
+        },
+        {
+          "paperId": "8c610b3a9dbcb3459559e926857e111493cb0c6f",
+          "title": "Lie algebras in $\\text{Ver}_4^+$"
+        },
+        {
+          "paperId": "8147bce49249f2c6d8e924b9b87175aa425c8668",
+          "title": "On the topological ranks of Banach $^*$-algebras associated with groups of subexponential growth"
+        },
+        {
+          "paperId": "872e70ee0a72c14b00b7829c8eff63e61f5a9980",
+          "title": "The elliptic Hall algebra and the double Dyck path algebra"
+        },
+        {
+          "paperId": "26183f4643f7cb21c5368704339771a797281bf6",
+          "title": "On the construction of polynomial Poisson algebras: a novel grading approach"
+        },
+        {
+          "paperId": "5dbf9b3f51f556a082eb53e691c177b166a93785",
+          "title": "Valuation rings in simple algebraic extensions of valued fields"
+        },
+        {
+          "paperId": "74e947702409cc5babb0f8c0e73cd995f6b5c294",
+          "title": "Characterizations of positive operators via their powers"
+        },
+        {
+          "paperId": "e879cd68eec77a50cbd28d8581f767a7f303751b",
+          "title": "Isometric classification of the $L^{p}$-spaces of infinite dimensional Lebesgue measure"
+        },
+        {
+          "paperId": "929f8570a62f8f001c93c6c0d8cac999feb3bd39",
+          "title": "Spectral and dynamical results related to certain non-integer base expansions on the unit interval"
+        },
+        {
+          "paperId": "11fe5992e939817e6c257f2a40c1c8a8fd98f3ba",
+          "title": "Sken and cluster algebras of punctured surfaces"
+        },
+        {
+          "paperId": "13f31a7283a6d98300fa65dcaa5a94aa9fb7af2d",
+          "title": "The polynomially convex embedding dimension for real manifolds of dimension $\\leq 11$"
+        },
+        {
+          "paperId": "17addc64313f9f3fed08e38937228950d57fda28",
+          "title": "Some Results on $\\mathrm{v}$-Number of Monomial Ideals"
+        }
+      ]
+    },
+    {
+      "paperId": "f83f0d8ecdac045245e240093f5ba87f000a9464",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "ac5982d423aea39c1482d5320a3676760cd31e77",
+          "title": "Divisible commutative semigroups"
+        },
+        {
+          "paperId": "ce0070ee64643f6e013ac61b08a3308e24000981",
+          "title": "Generalized seminear-fields"
+        },
+        {
+          "paperId": "239de54fa011517a148cbcc4959d9640f4b0c60c",
+          "title": "Generalized di ﬀ erential identities on prime rings and algebras"
+        },
+        {
+          "paperId": "943d3edf4369523a7c8899d2a9b45228020b0d7e",
+          "title": "Characterization of Monotone Sequences of Positive Numbers Prescribed by Means"
+        },
+        {
+          "paperId": "8d8face1e222173e37fb1a2fd05ce076f6dd02a1",
+          "title": "Supremum subsequence entropy for IP-sets"
+        },
+        {
+          "paperId": "e9c6bf40f71c538dbb2deac71c97f7e250dbac9e",
+          "title": "Generalized semifields"
+        },
+        {
+          "paperId": "c301d3e6f276f71cf32b58ddcd9f5b896716a04f",
+          "title": "Comptes Rendus Mathématique"
+        },
+        {
+          "paperId": "0e6c713ca363c13dcf7de072fd06bf0c06ee42a6",
+          "title": "Topological vector space over the quaternions"
+        },
+        {
+          "paperId": "09137876951f0af1535796a24b6774e699d4f903",
+          "title": "On the Sum of Divisors function of linearly recurrent sequences"
+        },
+        {
+          "paperId": "afe863cb7a867b7455a2eebd8e26f4bd47d4fa10",
+          "title": "Central limit theorems of sums of powers of function of independent random variables"
+        },
+        {
+          "paperId": "59646d882c12341ae21f6dbfad6564adfdd50516",
+          "title": "Outcome for the Case (11,10; 1) Outcome for the Case (11,10; 1)"
+        },
+        {
+          "paperId": "d7ef63f1218bdb9dac80f464714979133c1e8bac",
+          "title": "On lifting of embeddings between transitive models of set theory"
+        },
+        {
+          "paperId": "e398e9f95778a8193bcb8c5a2e2e1c44e3836913",
+          "title": "Second-Level Numerical Semigroups"
+        },
+        {
+          "paperId": "93f5cac0f03a8f774a42b785b52dfdbc0369de48",
+          "title": "On the Structure of σ_(1 )Near - Rings"
+        },
+        {
+          "paperId": "54569f2ca24dc62c282f787e197237ce45d08813",
+          "title": "Theorems of convex subgroups of semifields and vector spaces over semifields"
+        },
+        {
+          "paperId": "de671a0dfada0d98ebf38c2b049c1853f559a042",
+          "title": "Generalized transformation semigroups having proper dense subsemigroups"
+        },
+        {
+          "paperId": "7b7e484dfcf8b962944fc9fa49796dbcaded61b8",
+          "title": "Dynamical systems defined by polynomials with algebraic properties"
+        },
+        {
+          "paperId": "b51f7893d27694d764845df0087dd7eba48bfe35",
+          "title": "Random Modular Symbols"
+        },
+        {
+          "paperId": "8340501770b3b3f1edcd044fa0da5a3ee43f679b",
+          "title": "Abelian objects in categories with normal projections"
+        },
+        {
+          "paperId": "7ca3deab996cca0a9595855b3fad4ad57c0f7242",
+          "title": "Numerical radius peak multilinear mappings on ℓ1"
+        }
+      ]
+    },
+    {
+      "paperId": "8b60d15c9f3eed4d61d561bb01ec1e2fe5f126c9",
+      "title": "Some commutative algebra",
+      "recommendations": [
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        },
+        {
+          "paperId": "209589b6a1f4d3e0b5ab8310f0344e80aef53b65",
+          "title": "A Shape Lemma for Ideals of Differential Operators"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "8a0ff145d9705b805ed37376f1003ace06726bb6",
+          "title": "On some properties of Hopf manifolds"
+        },
+        {
+          "paperId": "73d92a46e4b598631c9d463418f51edc9e04a46e",
+          "title": "Relative Cancellation"
+        },
+        {
+          "paperId": "b9635489e9f49070a5b040d549d3657a519a60c8",
+          "title": "On the iterates of some multiplicative functions"
+        },
+        {
+          "paperId": "7e4f4f53b73bcea16c742d9e5327fa984295b003",
+          "title": "A note on the approximation of divisor functions"
+        },
+        {
+          "paperId": "d80a37f7314ac3d8826be780e4612a7c1e257355",
+          "title": "On Fefferman’s inequality. A simple proof"
+        },
+        {
+          "paperId": "122c673853396d206da0e0be7da31d483e3d0928",
+          "title": "On the Gorensteiness of string algebras"
+        },
+        {
+          "paperId": "b149f72fee40bd542e8f7ff703ca9c804eb0a48a",
+          "title": "Estimates for multiplicative functions, I."
+        },
+        {
+          "paperId": "ac7062feff58882e0fbabb87c860e2c6ccde7781",
+          "title": "Jordan property for automorphism groups of compact varieties"
+        },
+        {
+          "paperId": "ca7b04fc1de82ef33881964eb1f625befc2d6714",
+          "title": "Combinatorial properties of some big sets"
+        },
+        {
+          "paperId": "549d5d1354ae793f880c389ecf34fe74f7424d5d",
+          "title": "An analog of the Hille theorem for hypercomplex functions in a finite-dimensional commutative algebra"
+        },
+        {
+          "paperId": "185b835998f53a8d7a746fef64905cef39af7afc",
+          "title": "An explicit proof of the generalized Gauss-Bonnet formula"
+        },
+        {
+          "paperId": "fea924112c05b1673bf32f72189da7af7bd97c48",
+          "title": "A note on partial polynomial functions, in memory of Marek Jarnicki"
+        },
+        {
+          "paperId": "53bc21637ec930212ebef9b482cbc5d612d3ef52",
+          "title": "Arithmetic Langlands"
+        },
+        {
+          "paperId": "60dd700e745496cc4ca0baaa9e15cef4091a3891",
+          "title": "Isomorphish theorems for variants of some semigroups"
+        },
+        {
+          "paperId": "16a9c7404eb196bbd54ea52ec1fb71efc1acf077",
+          "title": "The main reasons for matrices multiplying to zero"
+        },
+        {
+          "paperId": "7e2ce9175bfe6bf0491b5a3240c519dfc5df7a23",
+          "title": "A generalization of the harmonic series"
+        },
+        {
+          "paperId": "c5c477a88c82b1aa64ed0d925a375c8b9950986a",
+          "title": "Comptes Rendus Mathématique"
+        }
+      ]
+    },
+    {
+      "paperId": "00833ede3ee78bb8c41615a271051ef6b5d18daa",
+      "title": "Hidden constructions in abstract algebra. Krull Dimension of distributive lattices and commutative rings",
+      "recommendations": [
+        {
+          "paperId": "f4ad2940d5a691888d2031db0f87cd16d005840e",
+          "title": "DUALITY AND A"
+        },
+        {
+          "paperId": "207d27544c67cbd231a56adf24a350fe6d9ffd83",
+          "title": "Representability for distributive quasi relation algebras via generalised ordinal sums"
+        },
+        {
+          "paperId": "f448ae3b2f5a81f64470dc3d7c181d1011606c54",
+          "title": "A PROJECTIVE SCALAR PROPERTY FOR SYMMETRIC ALGEBRAS"
+        },
+        {
+          "paperId": "4eee6ba01f88d2fbcb746fffc24f9c6c32b07e22",
+          "title": "Duality Theory for Bounded Lattices: A Comparative Study"
+        },
+        {
+          "paperId": "e3331f3b1685549893c7c6445f5aa386e2217fdb",
+          "title": "Inclusions of Operator Algebras from Tensor Categories: beyond irreducibility"
+        },
+        {
+          "paperId": "b7250de70e8386921cc1070b154a53a9bc2c5b82",
+          "title": "On the global dimension of Nakayama algebras"
+        },
+        {
+          "paperId": "35604917df60fd54383b28359b02b2f74a5c5bc7",
+          "title": "Remarks on skew Hilbert algebras and weak BCK*-algebras"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "182a87dbf62b7527c4b33160bd2ffb26e60aad62",
+          "title": "On covering theory and its applications"
+        },
+        {
+          "paperId": "0b0ebeb1185910d78c0612cf9e91d3c455240b4f",
+          "title": "Day algebras"
+        },
+        {
+          "paperId": "fdc799f3e1279fdde431b354267926e6af5bf4e9",
+          "title": "Some Notes on Generalized P-Derivations with Ideals in Factor Rings"
+        },
+        {
+          "paperId": "0a7c459b397fa2a2d2ba2b08edc4d31bfdf6cb53",
+          "title": "Matrix symmetric and quasi-symmetric functions and noncommutative representation theory"
+        },
+        {
+          "paperId": "51cb5020cbc827a5aa17d199a62cf4f979f99e1f",
+          "title": "Sharp elements in d 0 -algebras"
+        },
+        {
+          "paperId": "8fabbfb19624eb3edb4c1bffc5d8cf5453f469f3",
+          "title": "Rings in which every regular ideal is finitely generated"
+        },
+        {
+          "paperId": "95a370a78e201d522c3aa9ba43e0851b6b05ea40",
+          "title": "Nonsmooth Calabi-Yau structures for algebras and coalgebras"
+        },
+        {
+          "paperId": "4949b29de6114f975a4450d7ac75db19a9351c37",
+          "title": "Characterising properties of commutative rings using Witt vectors"
+        },
+        {
+          "paperId": "2cb22c2c5451c3d7ae0652c37ee5ce635e2176c3",
+          "title": "Artinian Gorenstein algebras with binomial Macaulay dual generator"
+        },
+        {
+          "paperId": "7b3375b8ff4cd6698b820487390b9b0b4899a390",
+          "title": "Generalized free wreath products and their operator algebras"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "f0d32196a2dc7bdc59abed75fd07c354bb6f90ef",
+          "title": "Noncommutative Resolutions of Singularities"
+        }
+      ]
+    },
+    {
+      "paperId": "6364a9a5d514b8f03fb2b83ce1956fd89ddd9854",
+      "title": "Homotopy Invariant Commutative Algebra over fields",
+      "recommendations": [
+        {
+          "paperId": "c9cfcd1b1e81d0d2af2a39fc01435d4c4ff1e8cb",
+          "title": "A linear AFL for quaternion algebras"
+        },
+        {
+          "paperId": "cbb662e9c53d7ef520f40823775f6ebdf6001ecf",
+          "title": "Structure of Algebras Satisfying an ω-Polynomial Identity of Degree Six"
+        },
+        {
+          "paperId": "27d96a06b6d478e0875526b9cf878e2012f75b32",
+          "title": "Brackets and Projective Geometry in Macaulay2"
+        },
+        {
+          "paperId": "90a4383ea36935a9a5e6069d3fd33dfb6660ce2c",
+          "title": "Isomorphisms of Birkhoff-James orthogonality on finite-dimensional $C^*$-algebra"
+        },
+        {
+          "paperId": "6ddd9b1f94854eaf1fc564331f4a5373f79d94ac",
+          "title": "Spectral Theory on Unital Commutative full Symmetric Krein C*-Algebras"
+        },
+        {
+          "paperId": "01f052b5cd915a341c9be5d412620e5443619e25",
+          "title": "Characterization and Cohomology of Crossed Homomorphisms on Lie Superalgebras"
+        },
+        {
+          "paperId": "677d1e5b6447fe7bddc9e7e38cb205ec29ea0470",
+          "title": "Differential Novikov algebras"
+        },
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        },
+        {
+          "paperId": "0b5ee362b8460c6e9bf2707461b4bfe6767990e7",
+          "title": "On the topology of real algebraic stacks"
+        },
+        {
+          "paperId": "6a9a23f2c82153b92e578012cf2013601d971ad5",
+          "title": "Gauge Modules Over The Lie Algebra Of Vector Fields"
+        },
+        {
+          "paperId": "122c673853396d206da0e0be7da31d483e3d0928",
+          "title": "On the Gorensteiness of string algebras"
+        },
+        {
+          "paperId": "84bcf532275277f9aa6ba2dd2ed405e11ad2a96f",
+          "title": "The equivariant covering homotopy property"
+        },
+        {
+          "paperId": "491097e66a9b31f8e5fee68345085262b867bae1",
+          "title": "Description of the structure of DG--algebras via characters on a groupoid"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "549d5d1354ae793f880c389ecf34fe74f7424d5d",
+          "title": "An analog of the Hille theorem for hypercomplex functions in a finite-dimensional commutative algebra"
+        },
+        {
+          "paperId": "60202db853b0f8a3510e5ca8fa3b860bf1cec2a1",
+          "title": "Comparing cohomology via exact split pairs in diagram algebras"
+        },
+        {
+          "paperId": "e9239d3a7c11b58fa182801060e06c077225efd1",
+          "title": "The Commutativity Condition of the Ring"
+        },
+        {
+          "paperId": "6b0dc607dac54a61c9343bd5329879b2d559ce4d",
+          "title": "Hilbert Grassmannians as classifying spaces"
+        },
+        {
+          "paperId": "a9d9c566a26a24aec3d8246247bf4779cdcb9758",
+          "title": "Derived invariants of gentle orders"
+        },
+        {
+          "paperId": "400b001f52b0226ea22d454c254220dad02843ac",
+          "title": "Homological Integrals for Weak Hopf Algebras"
+        }
+      ]
+    },
+    {
+      "paperId": "0306f61027deb70b83edb60e256762c610ce9f00",
+      "title": "Biderivations, linear commuting maps and commutative post-Lie algebra structures on W-algebras",
+      "recommendations": [
+        {
+          "paperId": "6ddd9b1f94854eaf1fc564331f4a5373f79d94ac",
+          "title": "Spectral Theory on Unital Commutative full Symmetric Krein C*-Algebras"
+        },
+        {
+          "paperId": "8e25e81979e257b13a5aa89edc14b03e6125b610",
+          "title": "On commutative isotopes of Jordan algebra of a symmetric bilinear nondegenerate form on a two-dimensional vector space"
+        },
+        {
+          "paperId": "b4b5ac90967969b3dd05d3810b40e4acf78ad8d7",
+          "title": "Non-associative Algebras of Cubic Matrices and their Gauge Theories"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "8acb68b347a57ae89abd38ab4f53e3df02d00644",
+          "title": "On the additivity of n-multiplicative isomorphisms, derivations, and related maps in axial algebras"
+        },
+        {
+          "paperId": "3377521c54c5c151b9ad9ce2fa785ca02dc3c43a",
+          "title": "Cohomology of Restricted Twisted Heisenberg Lie Algebras"
+        },
+        {
+          "paperId": "067cee0afc0e41c39e992df7bd34abdb31ae872e",
+          "title": "Isomorphism of Matrix Algebras over Cuntz Algebras"
+        },
+        {
+          "paperId": "727af3c07739323a2ac9315716e04eb130e59d21",
+          "title": "Derivations, 2-local derivations, biderivations and automorphisms of generalized Loop Heisenberg-Virasoro algebras"
+        },
+        {
+          "paperId": "e9239d3a7c11b58fa182801060e06c077225efd1",
+          "title": "The Commutativity Condition of the Ring"
+        },
+        {
+          "paperId": "a58faaa7ebed63ab68b1a867ef26d3e2bd9253b8",
+          "title": "Affineness on Noetherian graded rings, algebras and Hopf algebras"
+        },
+        {
+          "paperId": "5ce4f2577e22279e7f7192549f90359535c4fd84",
+          "title": "The K-theory of boundary C*-algebras of symmetric spaces"
+        },
+        {
+          "paperId": "95adb46144114bbe64f8c83bc95a561414b95247",
+          "title": "Algebras of analytic functionals and homological epimorphisms"
+        },
+        {
+          "paperId": "90a4383ea36935a9a5e6069d3fd33dfb6660ce2c",
+          "title": "Isomorphisms of Birkhoff-James orthogonality on finite-dimensional $C^*$-algebra"
+        },
+        {
+          "paperId": "1baa0d38569d34012569d8d4926d96f8b2925451",
+          "title": "Rota-Baxter Operators on Complex Semi-simple Algebras"
+        },
+        {
+          "paperId": "d80fb09083473c8953a59b49fb12976263849add",
+          "title": "Representations of Hamiltonian Lie algebras"
+        },
+        {
+          "paperId": "22ec4e8c99341819d4f0447e2d649061444fc488",
+          "title": "Non-existence of symmetric biderivations on finite-dimensional perfect Lie algebras"
+        },
+        {
+          "paperId": "60202db853b0f8a3510e5ca8fa3b860bf1cec2a1",
+          "title": "Comparing cohomology via exact split pairs in diagram algebras"
+        },
+        {
+          "paperId": "0f8d0f625d5d15badea74b5f9bad281a96df63d2",
+          "title": "Composition and Volterra-type inner derivations on the generalized Fock spaces"
+        },
+        {
+          "paperId": "6e15e0c54a3f44b3148a7bf12f7746dd9d969d29",
+          "title": "Commutativity of prime rings and Banach algebras with generalized ( β, α ) -derivations"
+        },
+        {
+          "paperId": "8998d3ea5b52481e3097715f9173d78afb5b8b37",
+          "title": "Remarks on the commutation relations between the Gauss--Weierstrass semigroup and monomial weights"
+        }
+      ]
+    },
+    {
+      "paperId": "2d5619ed9403068059725cdaaf1844092ec3cf59",
+      "title": "Commutative Algebra: Constructive Methods: Finite Projective Modules",
+      "recommendations": [
+        {
+          "paperId": "b3dc3820c2fc90075645d7148587a9c7f44a89e6",
+          "title": "Fundamental algebraic sets and locally unit-additive rings"
+        },
+        {
+          "paperId": "4a1436a80b8c21e871d4940737ccf901a91275d0",
+          "title": "Generalization of terms via universal algebra"
+        },
+        {
+          "paperId": "15ded360e47e22e03fefa2aec1600f35fafc85c2",
+          "title": "A Zoo of Continuity Properties in Constructive Type Theory"
+        },
+        {
+          "paperId": "3144ec0bad392e1446a007d26894be5e0bbabd4c",
+          "title": "Uniform Monad Presentations and Graph Quasitoposes"
+        },
+        {
+          "paperId": "c42eb3935c8b4c68f874a68bf591baf5bdbe461f",
+          "title": "Commutative Algebras with One-Dimensional Square"
+        },
+        {
+          "paperId": "fff79e4baee004ba1c0ef73fec6b3a9e36630de4",
+          "title": "Basic Concept of Isomorphism and its Use in Group Theory and Physics"
+        },
+        {
+          "paperId": "b5a16afe350ea9a61f84140bce1ca862ddaec081",
+          "title": "Stated Skein Theory and Double Affine Hecke Algebra Representations"
+        },
+        {
+          "paperId": "8aa4a3fb6a36ca5270676eea807f2908528b59d1",
+          "title": "Elliptic Curves"
+        },
+        {
+          "paperId": "da5d80abbb40fc017a02ec1a964e57cee4dc404b",
+          "title": "Homological properties of the module of differentials"
+        },
+        {
+          "paperId": "69a6501a61e69d977013b28203da9522a65020f4",
+          "title": "Exploring information geometry: Recent Advances and Connections to Topological Field Theory"
+        },
+        {
+          "paperId": "8a3216e0b837ec4c7580e6a763fcb0fa84a5db9b",
+          "title": "Can Yang-Baxter imply Lie algebra?"
+        },
+        {
+          "paperId": "d3519010c3c979246836d5116f3189cd2adfc4ad",
+          "title": "On Fuzzy ideal Homotopy Lifting Property"
+        },
+        {
+          "paperId": "9da11c05a8bdb553e1669bc4d4920aa7248e91cc",
+          "title": "Applications and Related Concepts of Orbit-Stabilizer Theorem"
+        },
+        {
+          "paperId": "0d036dfeadfbd66b5fc748524e6835b221c09fa0",
+          "title": "Carlitz operators and higher polylogarithm identities"
+        },
+        {
+          "paperId": "91f377550eb826d62bea4cb68266231392b1088c",
+          "title": "Algebraic K-theory of finite algebras over higher local fields"
+        },
+        {
+          "paperId": "844050a2afd31956bca4ce1ca1a9882c79a833fa",
+          "title": "Frobenius subalgebra lattices in tensor categories"
+        },
+        {
+          "paperId": "403dcde600bd144253f4add1608794d8ac247f94",
+          "title": "On the structure and theory of McCarthy algebras"
+        },
+        {
+          "paperId": "2f6fd3b34046e283c48b2aa6008ca16d4575fe7f",
+          "title": "Types of elements in non-commutative Poisson algebras and Dixmier Conjecture"
+        },
+        {
+          "paperId": "b44003d7257166e8bab009e9013686d91dd4ff88",
+          "title": "A Natural Transformation between the Model Constructions of the Completeness and Compactness Theorems, Enhanced by Rigidity and 2-Categorical Strengthening"
+        },
+        {
+          "paperId": "f37427a793c29ad3739ddfa1d9a207f53ce95f51",
+          "title": "A Survey on Lawvere's Fixed-Point Theorem"
+        }
+      ]
+    },
+    {
+      "paperId": "791bac37213173229f0842553a9a979401d6d9d8",
+      "title": "Combinatorics and commutative algebra",
+      "recommendations": [
+        {
+          "paperId": "134f10724b44d840eaae836132e87e05f95dacb4",
+          "title": "Advances in Applied Mathematics"
+        },
+        {
+          "paperId": "8367ac4e028fcd715b728537ca87e58d137d469c",
+          "title": "ALGEBRAIC COMBINATORICS"
+        },
+        {
+          "paperId": "b15a88b91a61d873fd848eb3463310fcb96b5aa4",
+          "title": "Topology and its Applications"
+        },
+        {
+          "paperId": "0a7c459b397fa2a2d2ba2b08edc4d31bfdf6cb53",
+          "title": "Matrix symmetric and quasi-symmetric functions and noncommutative representation theory"
+        },
+        {
+          "paperId": "ecae3c515a7fe5b63c7c899aa045f1bf861d1ace",
+          "title": "Bubble sort and Howe duality for staircase matrices"
+        },
+        {
+          "paperId": "c9813c049224f3576f3b997f507950708a5d5b79",
+          "title": "Leaf schemes and Hodge loci"
+        },
+        {
+          "paperId": "ec7065327adb76f0b9718126a24d6dd023059bed",
+          "title": "A multiplication formula for cluster characters in gentle algebras"
+        },
+        {
+          "paperId": "1f3b95982bf02e470f0a1b247a4ac567bc30e220",
+          "title": "COMBINATORIAL SUPERSYMMETRY: SUPERGROUPS, SUPERQUASIGROUPS, AND THEIR MULTIPLICATION GROUPS"
+        },
+        {
+          "paperId": "8aa4a3fb6a36ca5270676eea807f2908528b59d1",
+          "title": "Elliptic Curves"
+        },
+        {
+          "paperId": "9522719614f1abce5cbc6014e479e886626c4078",
+          "title": "Theory of Polyanalytic functions"
+        },
+        {
+          "paperId": "91986a056e711282e261f463421864f4b3e2c1cb",
+          "title": "Supersimplicty and arithmetic progressions"
+        },
+        {
+          "paperId": "8b9470a3c58718a54b6860409a0e96571a2ff235",
+          "title": "Some NP Complete Problems Based on Algebra and Algebraic Geometry"
+        },
+        {
+          "paperId": "9361a9563be817140c75494fe749f7e349ece705",
+          "title": "Topologies on abelian groups and a topological five-lemma"
+        },
+        {
+          "paperId": "d9a3ab1b34c8544c2dbb608b40e811fab4a49cf0",
+          "title": "On gcd-graphs over finite rings"
+        },
+        {
+          "paperId": "1a6cb418dad7402af81f187cf5d40a7f4f4d3a97",
+          "title": "Computation of Minimal Polynomials and Multivector Inverses in Non-Degenerate Clifford Algebras"
+        },
+        {
+          "paperId": "7510be2b7fcd752a49cd91a547b31f3577088a51",
+          "title": "Perspectives on the pure spinor superﬁeld formalism"
+        },
+        {
+          "paperId": "0d036dfeadfbd66b5fc748524e6835b221c09fa0",
+          "title": "Carlitz operators and higher polylogarithm identities"
+        },
+        {
+          "paperId": "794f413a73fdfec3b5d88f7164c9014d67b50ae8",
+          "title": "Diamond of triads"
+        },
+        {
+          "paperId": "bf1bbbbd86ee19d155a1c95265552f131c23ebe3",
+          "title": "Computing Connection Matrices of Conley Complexes via Algebraic Morse Theory"
+        },
+        {
+          "paperId": "6f53886b9679faf486f52860250b88007a9f163f",
+          "title": "EXPLORING THE VOLUME POLYNOMIAL AND M-CONVEXITY IN MATROID THEORY"
+        }
+      ]
+    },
+    {
+      "paperId": "b64861e1aef31447187e2f910d67db36f0a24ebb",
+      "title": "Monogenic Functions in a Finite-Dimensional Semi-Simple Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "549d5d1354ae793f880c389ecf34fe74f7424d5d",
+          "title": "An analog of the Hille theorem for hypercomplex functions in a finite-dimensional commutative algebra"
+        },
+        {
+          "paperId": "400b001f52b0226ea22d454c254220dad02843ac",
+          "title": "Homological Integrals for Weak Hopf Algebras"
+        },
+        {
+          "paperId": "95adb46144114bbe64f8c83bc95a561414b95247",
+          "title": "Algebras of analytic functionals and homological epimorphisms"
+        },
+        {
+          "paperId": "e80932fe569f9255a57389f78970e36226fbe339",
+          "title": "On spaces of functions associated to the canonical commutation relation"
+        },
+        {
+          "paperId": "8e25e81979e257b13a5aa89edc14b03e6125b610",
+          "title": "On commutative isotopes of Jordan algebra of a symmetric bilinear nondegenerate form on a two-dimensional vector space"
+        },
+        {
+          "paperId": "b24d833cf56379d31f4754cce5cd453aa18f3f95",
+          "title": "Duality theorems for polyanalytic functions"
+        },
+        {
+          "paperId": "702b8426def2eef497889f3592d984befbcb40cb",
+          "title": "Symmetric versus genuine symmetric forms in Hermitian K-theory"
+        },
+        {
+          "paperId": "b14b00aa5da5d00d14d1a9238af7cab2fc7e4dce",
+          "title": "Rigidity of Holomorphically Projective Mappings of Kähler and Hyperbolic Kähler Spaces with Finite Complete Geodesics"
+        },
+        {
+          "paperId": "e0cae7eb0f664e2ef64bff8afdc0a26f5d107e50",
+          "title": "MULTIPLICATIVE (IN)STABILITY OF BANACH ALGEBRAS"
+        },
+        {
+          "paperId": "42aaf21383066449250fca8d99127c4227b583d2",
+          "title": "Polynomial invariants for two-dimensional algebras"
+        },
+        {
+          "paperId": "6ddd9b1f94854eaf1fc564331f4a5373f79d94ac",
+          "title": "Spectral Theory on Unital Commutative full Symmetric Krein C*-Algebras"
+        },
+        {
+          "paperId": "0ce613fb9037263461a1d909ea5483d661439c1f",
+          "title": "An Algorithm for Computing Ideals and Conjugacy Classes of Subalgebras of Borel Subalgebras"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "bfe6ec3821c09f29b0aa3962f79e62a5a00ef3c0",
+          "title": "Topological Entropy of Regular Chaotic Quadratic Maps"
+        },
+        {
+          "paperId": "fbeae4630fc3928f66c6dea7e8aa2c9a2accc771",
+          "title": "Tight approximation for rationally simply connected varieties"
+        },
+        {
+          "paperId": "d80fb09083473c8953a59b49fb12976263849add",
+          "title": "Representations of Hamiltonian Lie algebras"
+        },
+        {
+          "paperId": "3377521c54c5c151b9ad9ce2fa785ca02dc3c43a",
+          "title": "Cohomology of Restricted Twisted Heisenberg Lie Algebras"
+        },
+        {
+          "paperId": "b4b5ac90967969b3dd05d3810b40e4acf78ad8d7",
+          "title": "Non-associative Algebras of Cubic Matrices and their Gauge Theories"
+        },
+        {
+          "paperId": "0a7c459b397fa2a2d2ba2b08edc4d31bfdf6cb53",
+          "title": "Matrix symmetric and quasi-symmetric functions and noncommutative representation theory"
+        },
+        {
+          "paperId": "5014d2f30a368d7f1ce0a8b06fbdda4fa14926de",
+          "title": "On the Hopf envelope of finite-dimensional bialgebras"
+        }
+      ]
+    }
+  ]
+}

--- a/test/papers_small.json
+++ b/test/papers_small.json
@@ -1,0 +1,358 @@
+{
+  "machine learning": [
+    {
+      "paperId": "0090023afc66cd2741568599057f4e82b566137c",
+      "title": "A Survey on Bias and Fairness in Machine Learning",
+      "recommendations": [
+        {
+          "paperId": "8f8478d74c312f8ac6b8d4fb9fc50e3e6ec2d549",
+          "title": "BIAS IN ARTIFICIAL INTELLIGENCE: AN ANALYSIS WITH SPECIAL FOCUS ON AUTOMATED CONTENT MODERATION"
+        },
+        {
+          "paperId": "91ce4e6ad8eb5227744df0f6c8e2bf4fd8d1d883",
+          "title": "Explaining Fairness Violations using Machine Unlearning"
+        },
+        {
+          "paperId": "c1dc05b322ff5f7bd784d056920772de9ed55b7d",
+          "title": "Exploration of Potential New Benchmark for Fairness Evaluation in Europe"
+        },
+        {
+          "paperId": "53a0bac11eee69dd2f95f683fb7851117c4f99d0",
+          "title": "From Laws to Algorithms: Detecting Unfairness in Machine Learning Models"
+        },
+        {
+          "paperId": "de89f6d78e6ca015cd44077f0072860f784b14a9",
+          "title": "Addressing Bias in Natural Language Processing (NLP) Models: Techniques and Implications"
+        }
+      ]
+    },
+    {
+      "paperId": "597bd2e45427563cdf025e53a3239006aa364cfc",
+      "title": "Open Graph Benchmark: Datasets for Machine Learning on Graphs",
+      "recommendations": [
+        {
+          "paperId": "33f9f146f4258a13889f75760502b230d472b039",
+          "title": "G-OSR: A Comprehensive Benchmark for Graph Open-Set Recognition"
+        },
+        {
+          "paperId": "a9c2f56ef61ec5ca6d8b47179aeec6999844e75d",
+          "title": "Exploring Graph Tasks with Pure LLMs: A Comprehensive Benchmark and Investigation"
+        },
+        {
+          "paperId": "f07646796bb0869712b185177e71d32d17b5e377",
+          "title": "GiGL: Large-Scale Graph Neural Networks at Snapchat"
+        },
+        {
+          "paperId": "9da5571ca6b8657af23bcb51fdf2ecc5a01ebf65",
+          "title": "Graph Neural Networks for Databases: A Survey"
+        },
+        {
+          "paperId": "ee0a9ccaa6ff27bb71bf3b867b2a4429ac48f6d6",
+          "title": "Towards Quantifying Long-Range Interactions in Graph Machine Learning: a Large Graph Dataset and a Measurement"
+        }
+      ]
+    }
+  ],
+  "information retrieval": [
+    {
+      "paperId": "08fb24d7e57db7de0da428676b1a0a6903051442",
+      "title": "Doubly Efficient Private Information Retrieval and Fully Homomorphic RAM Computation from Ring LWE",
+      "recommendations": [
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "195a8b3860758d92b967b26511900dc56d4a4995",
+          "title": "Efficient Linear Secure Computation and Symmetric Private Information Retrieval Protocols"
+        },
+        {
+          "paperId": "35b1e7726fcbd74fa0be99dba012462783dd5c65",
+          "title": "Non-Interactive Verifiable Aggregation"
+        },
+        {
+          "paperId": "c1fd692ced2db5f2f08d2f04c39c941e4a992161",
+          "title": "Labeled Private Set Intersection From Distributed Point Function"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        }
+      ]
+    },
+    {
+      "paperId": "f00fc5531564aef9205104dec31fe25c94e6b4ea",
+      "title": "Deceptive Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "ae1300fc1bac3f3ac89e618747cf42c06b89a697",
+          "title": "Practical Keyword Private Information Retrieval from Key-to-Index Mappings"
+        },
+        {
+          "paperId": "c17dc5a48d99465a08785e24c553c0a980a131e6",
+          "title": "Natural Language Processing for Improving Search Query Results"
+        },
+        {
+          "paperId": "7a76b13c94f7f74ab50bab93537902155c7f7e68",
+          "title": "Probabilistic analysis of data structures for locality-sensitive hashing functions"
+        }
+      ]
+    },
+    {
+      "paperId": "9af8bccf3e42996cbb198a6ceccafa2a084689f6",
+      "title": "HybridRAG: Integrating Knowledge Graphs and Vector Retrieval Augmented Generation for Efficient Information Extraction",
+      "recommendations": [
+        {
+          "paperId": "bb73fbee40cd09431b53a1a6b958b41f6701d8c4",
+          "title": "Talking to GDELT Through Knowledge Graphs"
+        },
+        {
+          "paperId": "3c22ea27cac88f9dbb4ea08fbdf44a1d9777978c",
+          "title": "Pseudo-Knowledge Graph: Meta-Path Guided Retrieval and In-Graph Text for RAG-Equipped LLM"
+        },
+        {
+          "paperId": "00e92a3b206b7acb75ddb6dfc5fdaa80190cec78",
+          "title": "PathRAG: Pruning Graph-based Retrieval Augmented Generation with Relational Paths"
+        },
+        {
+          "paperId": "d500f728daff3a345d945887f436a25c2a78eb91",
+          "title": "ArchRAG: Attributed Community-based Hierarchical Retrieval-Augmented Generation"
+        },
+        {
+          "paperId": "e2eb27ab435a3507c2926e39b4e47e763fc6e47f",
+          "title": "SRAG: Structured Retrieval-Augmented Generation for Multi-Entity Question Answering over Wikipedia Graph"
+        }
+      ]
+    },
+    {
+      "paperId": "859cbed6555319c3c31b84c1001a1df9a34889e2",
+      "title": "Evaluating Token-Level and Passage-Level Dense Retrieval Models for Math Information Retrieval",
+      "recommendations": [
+        {
+          "paperId": "53615f5e4d2587519be7ed0f2136d3150f2465e2",
+          "title": "Dense Passage Retrieval in Conversational Search"
+        },
+        {
+          "paperId": "8c321c3a2cb7737d23014879096bd709b01e44c5",
+          "title": "Optimizing Retrieval Strategies for Financial Question Answering Documents in Retrieval-Augmented Generation Systems"
+        },
+        {
+          "paperId": "5af10e53941c4256cdd8d27b04eb1ca8f1f76218",
+          "title": "From Retrieval to Generation: Comparing Different Approaches"
+        },
+        {
+          "paperId": "d1db1c018d37390ccfbd196703ad90c1fcdfb76f",
+          "title": "Pseudo-Relevance Feedback Can Improve Zero-Shot LLM-Based Dense Retrieval"
+        },
+        {
+          "paperId": "065ab6acd92293a0fb6124976a013cb1f2d1e060",
+          "title": "Teaching Dense Retrieval Models to Specialize with Listwise Distillation and LLM Data Augmentation"
+        }
+      ]
+    },
+    {
+      "paperId": "9fdf2f248f509361a5eae8fea2a3e2fc8692b2b1",
+      "title": "On Single Server Private Information Retrieval With Private Coded Side Information",
+      "recommendations": [
+        {
+          "paperId": "f6b22d8039e31adf80885c653b4404dbbece3e76",
+          "title": "A Low-Complexity Scheme for Multi-Message Private Information Retrieval"
+        },
+        {
+          "paperId": "8b43c483e532d67e9e053915118acec2b4fb6f3c",
+          "title": "Distributional Private Information Retrieval"
+        },
+        {
+          "paperId": "0173b93515e9956fc5942d3efeb00da8c5edb506",
+          "title": "On k-Mer-Based and Maximum Likelihood Estimation Algorithms for Trace Reconstruction"
+        },
+        {
+          "paperId": "1ef14f27b6f21cbe99f03317e14482b21a909fd7",
+          "title": "Non-Linear Function Computation Broadcast"
+        },
+        {
+          "paperId": "85be66dd85448f81c1f901f9928f4194d7713b7a",
+          "title": "Pseudorandom Functions with Weak Programming Privacy and Applications to Private Information Retrieval"
+        }
+      ]
+    }
+  ],
+  "mathematical physics": [
+    {
+      "paperId": "6311473c7c614ad29b5c0e6b94deec428219113f",
+      "title": "Asymptotic Methods in Equations of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "f7f21dda7101f2f5261202878ead97df8c1cae59",
+          "title": "NONLOCAL PROBLEMS FOR A MIXED PARABOLIC-HYPERBOLIC EQUATION OF THE THIRD ORDER"
+        },
+        {
+          "paperId": "39ad1eca0895611c3eb67eeab066e9fdd2a622ec",
+          "title": "Simple third order operator-splitting schemes for stochastic mechanics and field theory"
+        },
+        {
+          "paperId": "94604d1c33e97697434407aec5874dd3cf672c48",
+          "title": "On solvability of some boundary value problems for a nonlocal Poisson equation with periodic conditions"
+        },
+        {
+          "paperId": "4f077d26c6617b8494b0f6ec99866b2e3d3ac48a",
+          "title": "Recent advances about the rigorous integration of parabolic PDEs via fully spectral Fourier-Chebyshev expansions"
+        },
+        {
+          "paperId": "32b00467ed393593c279fa853cd85dc4f3876c5d",
+          "title": "Traveling-Wave Solutions of Several Nonlinear Mathematical Physics Equations"
+        }
+      ]
+    },
+    {
+      "paperId": "43cfaeca3d4dd1af8fa5e27754c47f050000c184",
+      "title": "Student’s need analysis in using ordinary differential equation e-module of Mathematical Physics II",
+      "recommendations": [
+        {
+          "paperId": "12116366691dc144a64126ea19b1e011b6cf3213",
+          "title": "Analysis of Mathematical Communication Skills of High School Students on Matrix Material"
+        },
+        {
+          "paperId": "7bf1368247a6fffdde38731bd4fcd519f1179250",
+          "title": "Analysis of Students' Mathematics Learning Outcomes on Matrix Concepts: A Comparative Study"
+        },
+        {
+          "paperId": "c0b9a3c5b2aed717e969b0d271fc4342f8fb9dcd",
+          "title": "Analysis of Students' Mathematical Problem-solving Ability on Number Matter"
+        },
+        {
+          "paperId": "5ae22fe72b0249d0e7134e95f74b5e1383ec276c",
+          "title": "The Effectiveness of the Realistic Mathematics Education Approach to Improve Students' Creativity in Learning Mathematics"
+        },
+        {
+          "paperId": "1cd6db00faca962c0fb5a957f50ba2916728fb39",
+          "title": "Resolving Learners Differences in the Learning of Mathematics"
+        }
+      ]
+    },
+    {
+      "paperId": "757dd5fbc67d8f2591eb2077180af74c1797fcd1",
+      "title": "Methods of Mathematical Physics",
+      "recommendations": [
+        {
+          "paperId": "99aeaeb44d0e6d84b396b1014dfccbc077b0d336",
+          "title": "Mechanics of nature"
+        },
+        {
+          "paperId": "32531d62cc2c2caa8e3869d4932945e2e27c733e",
+          "title": "The rise of stochasticity in physics"
+        },
+        {
+          "paperId": "4617bfe4a65da6fed870256c4ce4b4c124aab23d",
+          "title": "Hidden symmetries in Hamiltonian geometry, topology, physics and mechanics"
+        },
+        {
+          "paperId": "895b57ecf7d84216b9b5129c4b34cfbc31b51630",
+          "title": "A brief introduction to fluctuation theorems: from theory to experiments"
+        },
+        {
+          "paperId": "071e77e491f66966e666e92d2a31cf6092005bc2",
+          "title": "Algebraic and Positive Geometry of the Universe: from Particles to Galaxies"
+        }
+      ]
+    }
+  ],
+  "commutative algebra": [
+    {
+      "paperId": "a78c4d8308ec99087ec817b7984aaadbbf2ab25d",
+      "title": "Commutative Algebra: with a View Toward Algebraic Geometry",
+      "recommendations": [
+        {
+          "paperId": "6333bd4a53b8531ba1f21b6198cc602c45456106",
+          "title": "An elementary algebraic proof of the fundamental theorem of algebra"
+        },
+        {
+          "paperId": "fa6a1fe0626b0c857f8000a029d4ac57ff461ae4",
+          "title": "Aspects of Condensed Mathematics -- From Abstract Nonsense to Ergodic Theory"
+        },
+        {
+          "paperId": "209589b6a1f4d3e0b5ab8310f0344e80aef53b65",
+          "title": "A Shape Lemma for Ideals of Differential Operators"
+        },
+        {
+          "paperId": "82caac6e3215b78363330bbc5c4793b4755c9a96",
+          "title": "Homological dimensions over almost gentle algebras"
+        },
+        {
+          "paperId": "6a11a252c1ba215126442f0dac7429b07fc398c4",
+          "title": "Algebraic normalisation"
+        }
+      ]
+    },
+    {
+      "paperId": "c1e93692a09c773db1982a66c073682395ebe830",
+      "title": "Dirac Geometry I: Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "e678d86915e721bc1ba64557ec90b77209a01f7e",
+          "title": "On the emergence of an almost-commutative spectral triple from a geometric construction on a configuration space"
+        },
+        {
+          "paperId": "b45613565aabfde6dce5e736233546d76237f975",
+          "title": "Inverse Hamiltonian reduction in type A and generalized slices in the affine Grassmannian"
+        },
+        {
+          "paperId": "5ba55a93fc13e8294fdc7e7d069fa909ac12e51a",
+          "title": "Some Constructions on Quantum Principal Bundles"
+        },
+        {
+          "paperId": "f44128718dd9be180a5b0496934847f2728b44e5",
+          "title": "Dirac Operators on Orbifold Resolutions: Uniform Elliptic Theory"
+        },
+        {
+          "paperId": "a40f370af22a676bc127a008ca29839b88376489",
+          "title": "Quantization of Lie-Poisson algebra and Lie algebra solutions of mass-deformed type IIB matrix model"
+        }
+      ]
+    },
+    {
+      "paperId": "19bf4cc7bb782d3377302fa8692880e434551846",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "b356e50ca7c4d5ef5e1225e5e4fe0fd65dcbea39",
+          "title": "Symmetric 2-(35,17,8) designs with an automorphism of order 2"
+        }
+      ]
+    },
+    {
+      "paperId": "1a3c19d080a63e0b67890e32050ba832f9d596eb",
+      "title": "Commutative Algebra",
+      "recommendations": [
+        {
+          "paperId": "18efcede4d787ee0a58906c918e20f3f7204b3ab",
+          "title": "CW-complexes and Hilbert vector of standard graded Artinian Gorenstein algebras"
+        },
+        {
+          "paperId": "c9cfcd1b1e81d0d2af2a39fc01435d4c4ff1e8cb",
+          "title": "A linear AFL for quaternion algebras"
+        },
+        {
+          "paperId": "e9239d3a7c11b58fa182801060e06c077225efd1",
+          "title": "The Commutativity Condition of the Ring"
+        },
+        {
+          "paperId": "5c2dd1a4f4ea40c52ba27e5c393c6e493bc7cbd5",
+          "title": "Graded Frobenius algebras from tensor algebras of bimodules"
+        },
+        {
+          "paperId": "6ddd9b1f94854eaf1fc564331f4a5373f79d94ac",
+          "title": "Spectral Theory on Unital Commutative full Symmetric Krein C*-Algebras"
+        }
+      ]
+    }
+  ]
+}

--- a/test/scripts/generate_validation.py
+++ b/test/scripts/generate_validation.py
@@ -1,0 +1,97 @@
+import os
+import re
+import time
+import sys 
+import requests 
+import json 
+
+# The recommendation engine gave me some papers written in Thai
+# Use this kludge to filter out papers not written in English
+# (or at least anything not using a subset of the Latin alphabet)
+IS_PROBABLY_ENGLISH = re.compile(r'[a-zA-Z]+')
+
+# TODO: Use something less dumb
+def is_english_title(title):
+    return bool(re.match(IS_PROBABLY_ENGLISH, title))
+
+# Retrieve relevant papers from Semantic Scholar for given query
+def search_semantic_scholar(query, paper_limit=100, attempts=5):
+    url = "http://api.semanticscholar.org/graph/v1/paper/search/"
+    params = {
+        "query": query,
+        "limit": paper_limit,
+        "fields": "title,paperId",
+        "fieldsOfStudy" : "Mathematics", # NOTE: This can be removed, if needed
+        "sort" : "citationCount:desc"
+    }
+
+    # Semantic Scholar is rather stringent with its rate limits if you don't have an API key
+    # Apply exponential backoff to play nice
+    backoff = 5
+    for _ in range(attempts):
+        r = requests.get(url, params=params)
+        if r.status_code == 429:
+            backoff *= 2
+            time.sleep(backoff)
+            continue
+        return r.json().get("data", [])
+
+    # Failed to get data
+    return None 
+
+# Returns top k recommendations for a given paper
+def find_recommendations(ss_id, limit):
+    rsp = requests.get(f"https://api.semanticscholar.org/recommendations/v1/papers/forpaper/{ss_id}",
+                       params={'fields': 'title,paperId', 'limit': limit, 'sort' : 'citationCount:desc'})
+    rsp.raise_for_status()
+    results = rsp.json()
+    return results['recommendedPapers']
+
+# Write the papers to a JSON file
+def write_json(queries, papers_per_query, file_name, recs_per_paper):
+    data = {}
+    OVERSAMPLE = 2
+    for q in queries:
+        papers = search_semantic_scholar(q, papers_per_query)
+        if not papers:
+            print(f"Failed to retrieve query {q}")
+            continue
+
+        # Track papers for the JSON
+        papers_with_recs = []
+        rec_papers = 0
+        for paper in papers:
+            recs = find_recommendations(paper['paperId'], OVERSAMPLE * recs_per_paper)
+            
+            # Reject any paper that isn't written in English
+            recs = [rec for rec in recs if is_english_title(rec.get('title', ''))]
+            if len(recs) > recs_per_paper:
+                recs = recs[:recs_per_paper]
+
+            # Reject any paper that has no English recommendations
+            if not recs:
+                continue 
+
+            papers_with_recs.append(paper)
+            rec_papers += 1
+            paper['recommendations'] = recs
+            if rec_papers == recs_per_paper: # Hit recommendation target, can stop now
+                break 
+            
+        data[q] = papers_with_recs 
+
+    with open(file_name, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == '__main__':
+    num_papers = 100
+    recs_per_paper = 10
+    if len(sys.argv) > 2:
+        num_papers = int(sys.argv[1])
+        recs_per_paper = int(sys.argv[2])
+
+    QUERIES = ['machine learning', 'information retrieval', 'mathematical physics', 'commutative algebra']
+    papers_per_query = num_papers // len(QUERIES)
+    file_path = '../papers_small.json'
+    write_json(QUERIES, papers_per_query, file_path, recs_per_paper)


### PR DESCRIPTION
This PR adds the ability to programmatically generate a validation dataset for the recommender. It can be invoked by `python generate_validation.py <N> <R>`, where $N$ is the number of papers and $R$ the number of recommendations per paper. Example outputs can be found in the `test` directory